### PR TITLE
Removed direct cabal imports in Linker and Finder modules

### DIFF
--- a/compiler/ghci/Linker.lhs
+++ b/compiler/ghci/Linker.lhs
@@ -70,8 +70,6 @@ import System.Directory hiding (findFile)
 import System.Directory
 #endif
 
-import Distribution.Package hiding (depends, PackageId)
-
 import Exception
 \end{code}
 

--- a/compiler/main/Finder.lhs
+++ b/compiler/main/Finder.lhs
@@ -40,8 +40,6 @@ import UniqFM
 import Maybes           ( expectJust )
 import Exception        ( evaluate )
 
-import Distribution.Text
-import Distribution.Package hiding (PackageId)
 import Data.IORef       ( IORef, writeIORef, readIORef, atomicModifyIORef )
 import System.Directory
 import System.FilePath

--- a/compiler/main/PackageConfig.hs
+++ b/compiler/main/PackageConfig.hs
@@ -17,7 +17,10 @@ module PackageConfig (
         PackageIdentifier(..),
         defaultPackageConfig,
         packageConfigToInstalledPackageInfo,
-        installedPackageInfoToPackageConfig
+        installedPackageInfoToPackageConfig,
+        packageName,
+        PackageName(..),
+        simpleParse
     ) where
 
 #include "HsVersions.h"


### PR DESCRIPTION
After reviewing the ghc and ghc-pkg dependencies wrt to Cabal modules, I noticed that PackageConfig and Packages, for the most part, are serving as a facade to Cabal modules. That is true except for Linker, Finder and GhcUtils, and this super small pull request rectifies that.

Here is a summary of the dependencies to Cabal modules (wrong dependencies, imho, are marked in red):

![ghc-2](https://f.cloud.github.com/assets/1887682/219436/f01fbe8a-852e-11e2-994b-f2f327b3370f.png)

With the exception of Packages.InstalledPackageId, most of the imports are minor and imo don't justify bring in Cabal as a whole for that. It seems to me that core dependencies such as InstalledPackageId should be either cloned (are there ghc specific fields here?) or moved to a pure library that could be shared by Cabal and GHC.
