### PR TITLE
Fix comment about pointer tagging

### DIFF
--- a/compiler/codeGen/StgCmmExpr.hs
+++ b/compiler/codeGen/StgCmmExpr.hs
@@ -872,7 +872,7 @@ emitEnter fun = do
       -- The generated code will be something like this:
       --
       --    R1 = fun  -- copyout
-      --    if (fun & 7 != 0) goto Lcall else goto Lret
+      --    if (fun & 7 != 0) goto Lret else goto Lcall
       --  Lcall:
       --    call [fun] returns to Lret
       --  Lret:


### PR DESCRIPTION
`Lcall` enters the closure. If it has tags we jump directly to `Lret`. 

Confirmed with some generated cmm code: 

```
           R1 = _s2pP::P64;
           Sp = Sp - 8;
           if (R1 & 7 != 0) goto c2x0; else goto c2x1;
       c2x1:
           call (I64[R1])(R1) returns to c2x0, args: 8, res: 8, upd: 8;
       c2x0:
           _s2pQ::P64 = R1;
```