### PR TITLE
Fix documentation NOTE about can_fail

### DIFF
--- a/compiler/prelude/PrimOp.hs
+++ b/compiler/prelude/PrimOp.hs
@@ -356,7 +356,7 @@ The can_fail and has_side_effects properties have the following effect
 on program transformations.  Summary table is followed by details.
 
             can_fail     has_side_effects
-Discard        NO            NO
+Discard        YES           NO
 Float in       YES           YES
 Float out      NO            NO
 Duplicate      YES           NO


### PR DESCRIPTION
In the note it is explained why it's fine to discard a can_fail primop, but the table erroneously says it's not fine.