### PR TITLE
Fix a tiny typo

### DIFF
--- a/libraries/base/System/IO.hs
+++ b/libraries/base/System/IO.hs
@@ -426,7 +426,7 @@ fixIO k = do
 -- | The function creates a temporary file in ReadWrite mode.
 -- The created file isn\'t deleted automatically, so you need to delete it manually.
 --
--- The file is creates with permissions such that only the current
+-- The file is created with permissions such that only the current
 -- user can read\/write it.
 --
 -- With some exceptions (see below), the file will be created securely


### PR DESCRIPTION
This pull request fixes a tiny typo.

By the way, I'm wondering what the security implications of the random number generator used for creating temporary file names being entirely predictable (it's just using the PID and a sequential number) are. Probably none on local filesystems thanks to O_EXCL and O_CREAT.