### PR TITLE
Fix space leak in sortBy

### DIFF
--- a/libraries/base/Data/OldList.hs
+++ b/libraries/base/Data/OldList.hs
@@ -854,14 +854,15 @@ sortBy cmp = mergeAll . sequences
 
     ascending a as (b:bs)
       | a `cmp` b /= GT = ascending b (\ys -> as (a:ys)) bs
-    ascending a as bs   = as [a]: sequences bs
+    ascending a as bs   = let x = as [a] in x `seq` x : sequences bs
 
     mergeAll [x] = x
     mergeAll xs  = mergeAll (mergePairs xs)
 
-    mergePairs (a:b:xs) = merge a b: mergePairs xs
+    mergePairs (a:b:xs) = let x = merge a b in x `seq` x : mergePairs xs
     mergePairs xs       = xs
 
+    {-# INLINE merge #-}
     merge as@(a:as') bs@(b:bs')
       | a `cmp` b == GT = b:merge as  bs'
       | otherwise       = a:merge as' bs


### PR DESCRIPTION
Fix a space leak in sortBy, significantly increasing the performance of sorting random integers (about 30%) and strings (about 18%). Performance for sorting already sorted lists (both ascending and descending) is just slightly faster. Many thanks to Siddhanathan Shanmugam for helping me with this.