### PR TITLE
Build system: fix `INSTALLED_GHC{,_PKG}_REAL` when installing cross-compiled binary distribution on TARGET

### DIFF
--- a/ghc.mk
+++ b/ghc.mk
@@ -962,7 +962,7 @@ endif
 
 INSTALLED_PACKAGE_CONF=$(DESTDIR)$(topdir)/package.conf.d
 
-ifeq "$(CrossCompiling)" "YES"
+ifeq "$(BINDIST) $(CrossCompiling)" "NO YES"
 # when installing ghc-stage2 we can't run target's
 # 'ghc-pkg' and 'ghc-stage2' but those are needed for registration.
 INSTALLED_GHC_REAL=$(TOP)/inplace/bin/ghc-stage1

--- a/mk/config.mk.in
+++ b/mk/config.mk.in
@@ -415,11 +415,12 @@ GhcRtsWithLibdw=$(strip $(if $(filter $(TargetArch_CPP),i386 x86_64),@UseLibdw@,
 #
 ################################################################################
 
-BIN_DIST_NAME         = ghc-$(ProjectVersion)
-BIN_DIST_PREP_DIR     = bindistprep/$(BIN_DIST_NAME)
-BIN_DIST_PREP_TAR     = bindistprep/$(BIN_DIST_NAME)-$(TARGETPLATFORM).tar
+BINDIST                = no
+BIN_DIST_NAME          = ghc-$(ProjectVersion)
+BIN_DIST_PREP_DIR      = bindistprep/$(BIN_DIST_NAME)
+BIN_DIST_PREP_TAR      = bindistprep/$(BIN_DIST_NAME)-$(TARGETPLATFORM).tar
 BIN_DIST_PREP_TAR_COMP = $(BIN_DIST_PREP_TAR).$(TAR_COMP_EXT)
-BIN_DIST_TAR_COMP     = $(BIN_DIST_NAME)-$(TARGETPLATFORM).tar.$(TAR_COMP_EXT)
+BIN_DIST_TAR_COMP      = $(BIN_DIST_NAME)-$(TARGETPLATFORM).tar.$(TAR_COMP_EXT)
 
 # -----------------------------------------------------------------------------
 # Utilities programs: flags


### PR DESCRIPTION
`make install` from a cross-compiled binary distribution will fail to run `$(ghc-cabal_INPLACE) register` in the rule `install_packages` if the old incorrect `INSTALLED_GHC{,_PKG}_REAL` are used:

```
$ utils/ghc-pkg/dist-install/build/tmp/ghc-pkg
...
error while loading shared libraries:
libHSterminfo-0.4.0.2-ghc8.3.20170419.so: cannot open shared object file: No such file or directory
```