### PR TITLE
Don't describe tuple sections as "Python-style"

### DIFF
--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -1570,7 +1570,7 @@ Tuple sections
 
     Allow the use of tuple section syntax
 
-The :ghc-flag:`-XTupleSections` flag enables Python-style partially applied
+The :ghc-flag:`-XTupleSections` flag enables partially applied
 tuple constructors. For example, the following program ::
 
       (, True)


### PR DESCRIPTION
I think this comparison introduces more confusion than clarity. Python, as far as I know, doesn't have any feature that resembles tuple sections. From [this discussion](https://www.reddit.com/r/programming/comments/93wwn/ghc_gets_pythonstyle_tuple_sections/) it seems like a bunch of other people were also confused by this when it came out.