### PR TITLE
Update broken nm message

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -526,7 +526,7 @@ then
             echo
             echo "Try re-running configure with:"
             echo
-            echo '   ./configure --with-nm=$(xcrun --find nm-classic)'
+            echo '   NM=$(xcrun --find nm-classic) ./configure'
             echo
             exit 1
             ;;


### PR DESCRIPTION
9373994acaf1b73fe0e7cf8e03594c63cec8d235 killed the `--with-*` arguments for `configure`.