### PR TITLE
Fix crash in isModuleInterpreted for HsBoot (fixes #13591)

### DIFF
--- a/compiler/main/GHC.hs
+++ b/compiler/main/GHC.hs
@@ -112,7 +112,7 @@ module GHC (
         moduleIsInterpreted,
         getInfo,
         showModule,
-        isModuleInterpreted,
+        moduleIsBootOrNotObjectLinkable,
 
         -- ** Inspecting types and kinds
         exprType, TcRnExprMode(..),

--- a/ghc/GHCi/UI.hs
+++ b/ghc/GHCi/UI.hs
@@ -1793,7 +1793,7 @@ modulesLoadedMsg ok mods = do
   dflags <- getDynFlags
   unqual <- GHC.getPrintUnqual
   let mod_name mod = do
-        is_interpreted <- GHC.isModuleInterpreted mod
+        is_interpreted <- GHC.moduleIsBootOrNotObjectLinkable mod
         return $ if is_interpreted
                   then ppr (GHC.ms_mod mod)
                   else ppr (GHC.ms_mod mod)


### PR DESCRIPTION
Rename isModuleInterpreted to moduleIsBootOrNotObjectLinkable
because a) there already is a moduleIsInterpreted function in
the same module b) I have no idea if the (new) semantic of
the bool returned matches some understanding of "is interpreted".

This code now defaults to returning True for hs-boot files, which might
not be "correct". This choice was made due to the uses of this function:
It leads to sensible output in HscTypes:showModMsg and UI:modulesLoadedMsg.
The fix for #9887 (i.e. 41051dd) introduced (or at least exposed) this bug and
consequently it never worked for hs-boot.
This patch does not fix that; it just prevents the exception.
