### PR TITLE
Fix Haddock markup

### DIFF
--- a/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
+++ b/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
@@ -1538,7 +1538,7 @@ data Exp
   | ConE Name                          -- ^ @data T1 = C1 t1 t2; p = {C1} e1 e2  @
   | LitE Lit                           -- ^ @{ 5 or \'c\'}@
   | AppE Exp Exp                       -- ^ @{ f x }@
-  | AppTypeE Exp Type                  -- ^ @{ f \@Int }
+  | AppTypeE Exp Type                  -- ^ @{ f \@Int }@
 
   | InfixE (Maybe Exp) Exp (Maybe Exp) -- ^ @{x + y} or {(x+)} or {(+ x)} or {(+)}@
 


### PR DESCRIPTION
This fixes Haddock markup for `AppTypeE` constructor of `Exp` type.

Also markup for `UnboundVarE` constructor at line 1584
https://github.com/vagarenko/ghc/blob/0b876e1ec56459dcb79817b7760182d7a95acbd0/libraries/template-haskell/Language/Haskell/TH/Syntax.hs#L1584
looks suspicious. Should it be fixed same way?