### PR TITLE
Add missing "do" to example in arrow docs.

### DIFF
--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -11671,7 +11671,7 @@ abstraction.
 We could define our own operator ::
 
     untilA :: ArrowChoice a => a (e,s) () -> a (e,s) Bool -> a (e,s) ()
-    untilA body cond = proc x ->
+    untilA body cond = proc x -> do
             b <- cond -< x
             if b then returnA -< ()
             else do


### PR DESCRIPTION
I'm getting a parse error on this example without this change. After this change the example parses and compiles.