### PR TITLE
Add flag to hide the loaded modules in ghci

### DIFF
--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -525,6 +525,7 @@ data GeneralFlag
    | Opt_OptimalApplicativeDo
    | Opt_VersionMacros
    | Opt_WholeArchiveHsLibs
+   | Opt_HideLoadedMods -- Hide lists of loaded modules in ghci
 
    -- PreInlining is on by default. The option is there just to see how
    -- bad things get if you turn it off!
@@ -3760,7 +3761,8 @@ fFlagsDeps = [
   flagSpec "show-warning-groups"              Opt_ShowWarnGroups,
   flagSpec "hide-source-paths"                Opt_HideSourcePaths,
   flagSpec "show-hole-constraints"            Opt_ShowHoleConstraints,
-  flagSpec "whole-archive-hs-libs"            Opt_WholeArchiveHsLibs
+  flagSpec "whole-archive-hs-libs"            Opt_WholeArchiveHsLibs,
+  flagGhciSpec "hide-loaded-modules"          Opt_HideLoadedMods
   ]
 
 -- | These @-f\<blah\>@ flags can all be reversed with @-fno-\<blah\>@

--- a/docs/users_guide/ghci.rst
+++ b/docs/users_guide/ghci.rst
@@ -123,6 +123,8 @@ modules are required, directly or indirectly, by the topmost module, and load
 them all in dependency order. The :ghc-flag:`-hide-loaded-modules` flag
 can be used to suppress the full list of loaded modules before the prompt.
 
+.. _ghci-hide-loaded-modules:
+
 .. [3]
    If you started up GHCi from the command line then GHCi's current
    directory is the same as the current directory of the shell from

--- a/docs/users_guide/ghci.rst
+++ b/docs/users_guide/ghci.rst
@@ -120,7 +120,8 @@ name of the "topmost" module to the :ghci-cmd:`:load` command (hint:
 :ghci-cmd:`:load` can be abbreviated to ``:l``). The topmost module will
 normally be ``Main``, but it doesn't have to be. GHCi will discover which
 modules are required, directly or indirectly, by the topmost module, and load
-them all in dependency order.
+them all in dependency order. The :ghc-flag:`-hide-loaded-modules` flag
+can be used to suppress the full list of loaded modules before the prompt.
 
 .. [3]
    If you started up GHCi from the command line then GHCi's current

--- a/ghc/GHCi/UI.hs
+++ b/ghc/GHCi/UI.hs
@@ -1816,7 +1816,14 @@ modulesLoadedMsg ok mods = do
                    Failed    -> text "Failed"
                    Succeeded -> text "Ok"
 
-      msg = status <> text ", modules loaded:" <+> mod_commas
+      append_mod_commas = if gopt Opt_HideLoadedMods dflags
+        then ""
+        else ":" <+> mod_commas
+      numMods = length mod_names
+      numModsPP = if numMods == 1
+        then "1 module"
+        else int numMods <+> "modules"
+      msg = status <> text "," <+> numModsPP <+> "loaded" <> append_mod_commas
 
   when (verbosity dflags > 0) $
      liftIO $ putStrLn $ showSDocForUser dflags unqual msg

--- a/utils/mkUserGuidePart/Options/Interactive.hs
+++ b/utils/mkUserGuidePart/Options/Interactive.hs
@@ -62,4 +62,10 @@ interactiveOptions =
            "expressions in GHCi <ghci-interactive-print>`"
          , flagType = DynamicFlag
          }
+  , flag { flagName = "-hide-loaded-modules"
+         , flagDescription =
+           ":ref:`Do not print the module list before the prompt " ++
+           "<ghci-hide-loaded-modules>`"
+         , flagType = DynamicFlag
+         }
   ]


### PR DESCRIPTION
They're quite an eyesore when you have 200+ modules, but `v0` does not show progress.