### PR TITLE
improve the docs for finalizers to clarify when finalizers may not be run

### DIFF
--- a/libraries/base/System/Mem/Weak.hs
+++ b/libraries/base/System/Mem/Weak.hs
@@ -146,7 +146,7 @@ A heap object is /reachable/ if:
 
 {- $notes
 
-A finalizers is not always called after its weak pointer\'s object becomes
+A finalizer is not always called after its weak pointer\'s object becomes
 unreachable. There are two situations that can cause this:
 
  * If the object becomes unreachable right before the program exits,
@@ -160,8 +160,8 @@ unreachable. There are two situations that can cause this:
    discouraged.
 
 Other than these two caveats, users can always expect that a finalizer
-will be after its weak pointer\'s object becomes unreachable. However,
-the second caveats means that users need to trust that all of their
+will be run after its weak pointer\'s object becomes unreachable. However,
+the second caveat means that users need to trust that all of their
 transitive dependencies do not throw exceptions in finalizers, since
 any finalizers can end up queued together.
 

--- a/libraries/base/System/Mem/Weak.hs
+++ b/libraries/base/System/Mem/Weak.hs
@@ -67,6 +67,10 @@ module System.Mem.Weak (
         -- * A precise semantics
 
         -- $precise
+
+        -- * Implementation notes
+        
+        -- $notes
    ) where
 
 import GHC.Weak
@@ -140,3 +144,25 @@ A heap object is /reachable/ if:
  * It is the value or finalizer of a weak pointer object whose key is reachable.
 -}
 
+{- $notes
+
+A finalizers is not always called after its weak pointer\'s object becomes
+unreachable. There are two situations that can cause this:
+
+ * If the object becomes unreachable right before the program exits,
+   then GC may not be performed. Finalizers run during GC, so finalizers
+   associated with the object do not run if GC does not happen.
+
+ * If a finalizer throws an exception, subsequent finalizers that had
+   been queued to run after it do not get run. This behavior may change
+   in a future release. See issue <https://ghc.haskell.org/trac/ghc/ticket/13167 13167>
+   on the issue tracker. Writing a finalizer that throws exceptions is
+   discouraged.
+
+Other than these two caveats, users can always expect that a finalizer
+will be after its weak pointer\'s object becomes unreachable. However,
+the second caveats means that users need to trust that all of their
+transitive dependencies do not throw exceptions in finalizers, since
+any finalizers can end up queued together.
+
+-}


### PR DESCRIPTION
Adds documentation to `System.Mem.Weak` to clarify what guarantees users can expect about finalizers being run. This doesn't fix https://ghc.haskell.org/trac/ghc/ticket/13167, but it documents the problem.