### PR TITLE
Add forgotten > in Control.Applicative

### DIFF
--- a/libraries/base/Control/Applicative.hs
+++ b/libraries/base/Control/Applicative.hs
@@ -107,7 +107,7 @@ newtype ZipList a = ZipList { getZipList :: [a] }
 
 -- |
 -- > f '<$>' 'ZipList' xs1 '<*>' ... '<*>' 'ZipList' xsN
---       = 'ZipList' (zipWithN f xs1 ... xsN)
+-- >     = 'ZipList' (zipWithN f xs1 ... xsN)
 --
 -- where @zipWithN@ refers to the @zipWith@ function of the appropriate arity
 -- (@zipWith@, @zipWith3@, @zipWith4@, ...). For example:


### PR DESCRIPTION
As reported by tabaqui on `#hackage`

Haddocks look silly atm: https://hackage.haskell.org/package/base-4.10.0.0/docs/Control-Applicative.html#t:ZipList