### PR TITLE
Fix string escaping in Json

### DIFF
--- a/compiler/utils/Json.hs
+++ b/compiler/utils/Json.hs
@@ -39,7 +39,7 @@ escapeJsonString = concatMap escapeChar
     escapeChar '\n' = "\\n"
     escapeChar '\r' = "\\r"
     escapeChar '\t' = "\\t"
-    escapeChar '"'  = "\""
+    escapeChar '"'  = "\\\""
     escapeChar '\\'  = "\\\\"
     escapeChar c | isControl c || fromEnum c >= 0x7f  = uni_esc c
     escapeChar c = [c]


### PR DESCRIPTION
It seems that double quotes is not escaped properly at the moment.

We'd noticed this with @alexbiehl during the work on https://github.com/haskell/haddock/pull/645