### PR TITLE
Fix Applicative doc code

### DIFF
--- a/libraries/base/GHC/Base.hs
+++ b/libraries/base/GHC/Base.hs
@@ -379,6 +379,7 @@ class  Functor f  where
 -- the same as their default definitions:
 --
 --      @('<*>') = 'liftA2' 'id'@
+--
 --      @'liftA2' f x y = f '<$>' x '<*>' y@
 --
 -- Further, any definition must satisfy the following:


### PR DESCRIPTION
Due to a missing newline between the `@`, Haddock does not render the two-line example correctly. Inserting a blank line should fix the issue.

> ![selection_003](https://user-images.githubusercontent.com/3020161/29209925-5ffebb6a-7e91-11e7-90c0-1018688fdb71.png)

