### PR TITLE
Remove broken citeseer citation links

### DIFF
--- a/docs/users_guide/bugs.rst
+++ b/docs/users_guide/bugs.rst
@@ -143,7 +143,7 @@ group is generalised (`Haskell Report, Section
 4.5.2 <http://www.haskell.org/onlinereport/decls.html#sect4.5.2>`__).
 
 Following a suggestion of Mark Jones, in his paper `Typing Haskell in
-Haskell <http://citeseer.ist.psu.edu/424440.html>`__, GHC implements a
+Haskell <https://web.cecs.pdx.edu/~mpj/thih/>`__, GHC implements a
 more general scheme. In GHC *the dependency analysis ignores references to
 variables that have an explicit type signature*. As a result of this refined
 dependency analysis, the dependency groups are smaller, and more bindings will

--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -5730,7 +5730,7 @@ More documentation can be found in the `Haskell Wiki
 
 .. [Jones2000]
     "`Type Classes with Functional
-    Dependencies <http://citeseer.ist.psu.edu/jones00type.html>`__",
+    Dependencies <https://web.cecs.pdx.edu/~mpj/pubs/fundeps.html>`__",
     Mark P. Jones, In *Proceedings of the 9th European Symposium on Programming*,
     ESOP 2000, Berlin, Germany, March 2000, Springer-Verlag LNCS 1782, .
 


### PR DESCRIPTION
These two citeseer links redirect to a login page. I propose linking to Mark Jones's website instead.