### PR TITLE
Add non-ASCII isLetter True example

### DIFF
--- a/libraries/base/Data/Char.hs
+++ b/libraries/base/Data/Char.hs
@@ -132,6 +132,8 @@ digitToInt c
 -- True
 -- >>> isLetter 'A'
 -- True
+-- >>> isLetter 'λ'
+-- True
 -- >>> isLetter '0'
 -- False
 -- >>> isLetter '%'


### PR DESCRIPTION
I didn't find it immediately obvious from the documentation whether `isLetter` could produce `True` for any non-ASCII characters - it seemed plausible that only `[a-zA-Z]` would count. I figure one more example just to make this explicit can't hurt.