### PR TITLE
Data.Maybe: generalize catMaybes

### DIFF
--- a/libraries/base/Data/Maybe.hs
+++ b/libraries/base/Data/Maybe.hs
@@ -252,8 +252,8 @@ listToMaybe (a:_)     =  Just a
 -- >>> catMaybes $ [readMaybe x :: Maybe Int | x <- ["1", "Foo", "3"] ]
 -- [1,3]
 --
-catMaybes              :: [Maybe a] -> [a]
-catMaybes ls = [x | Just x <- ls]
+catMaybes :: (Monad m, Alternative m) => m (Maybe a) -> m a
+catMaybes = (>>= maybe empty pure)
 
 -- | The 'mapMaybe' function is a version of 'map' which can throw
 -- out elements.  In particular, the functional argument returns

--- a/testsuite/tests/ghci/scripts/ghci023.stdout
+++ b/testsuite/tests/ghci/scripts/ghci023.stdout
@@ -3,7 +3,8 @@
 (1,2,3)
 -- layout rule instead of explicit braces and semicolons works too
 (1,2,3)
-Data.Maybe.catMaybes :: [Maybe a] -> [a]
+Data.Maybe.catMaybes ::
+  (Monad m, GHC.Base.Alternative m) => m (Maybe a) -> m a
 Data.Maybe.fromJust :: Maybe a -> a
 Data.Maybe.fromMaybe :: a -> Maybe a -> a
 Data.Maybe.isJust :: Maybe a -> Bool

--- a/testsuite/tests/ghci/scripts/ghci025.stdout
+++ b/testsuite/tests/ghci/scripts/ghci025.stdout
@@ -24,7 +24,8 @@ return :: Monad m => forall a. a -> m a
 class GHC.Base.Applicative m => Monad (m :: * -> *)
   ...
 -- imported via Data.Maybe
-catMaybes :: [Maybe a] -> [a]
+catMaybes ::
+  (Monad m, GHC.Base.Alternative m) => m (Maybe a) -> m a
 fromJust :: Maybe a -> a
 fromMaybe :: a -> Maybe a -> a
 isJust :: Maybe a -> GHC.Types.Bool

--- a/testsuite/tests/ghci/scripts/ghci026.stdout
+++ b/testsuite/tests/ghci/scripts/ghci026.stdout
@@ -1,4 +1,5 @@
-catMaybes :: [Maybe a] -> [a]
+catMaybes ::
+  (Monad m, GHC.Base.Alternative m) => m (Maybe a) -> m a
 fromJust :: Maybe a -> a
 fromMaybe :: a -> Maybe a -> a
 isJust :: Maybe a -> Bool

--- a/testsuite/tests/typecheck/should_compile/valid_substitutions.stderr
+++ b/testsuite/tests/typecheck/should_compile/valid_substitutions.stderr
@@ -20,7 +20,9 @@ valid_substitutions.hs:13:8: warning: [-Wtyped-holes (in -Wdefault)]
                      a
           (imported from ‘Prelude’ at valid_substitutions.hs:3:1-30
            (and originally defined in ‘GHC.Err’))
-        catMaybes :: forall a. [Maybe a] -> [a]
+        catMaybes :: forall (m :: * -> *) a.
+                     (Monad m, GHC.Base.Alternative m) =>
+                     m (Maybe a) -> m a
           (imported from ‘Data.Maybe’ at valid_substitutions.hs:5:1-17)
 
 valid_substitutions.hs:16:9: warning: [-Wtyped-holes (in -Wdefault)]


### PR DESCRIPTION
This seems like an innocuous change: the test results are the same as before, and `catMaybes` is slightly better. It now works with other list-like structures. Is this kind of change wanted?