### PR TITLE
change example from msum to mfilter

### DIFF
--- a/libraries/base/Control/Monad.hs
+++ b/libraries/base/Control/Monad.hs
@@ -276,7 +276,7 @@ The functions in this library use the following naming conventions:
 * A prefix \'@m@\' generalizes an existing function to a monadic form.
   Thus, for example:
 
-> sum  :: Num a       => [a]   -> a
-> msum :: MonadPlus m => [m a] -> m a
+> filter  ::                (a -> Bool) -> [a] -> [a]
+> mfilter :: MonadPlus m => (a -> Bool) -> m a -> m a
 
 -}


### PR DESCRIPTION
Since `msum` does not do what I think most people intuitively understand as *summing*, I thought the example in the naming conventions documentation was a little misleading. I thought perhaps changing that example to contrast `filter` and `mfilter` would be more illustrative since there is not a discrepancy in the (probably, intuitively) expected result.