### PR TITLE
change bifunctor documentation; add examples

### DIFF
--- a/libraries/base/Data/Bifunctor.hs
+++ b/libraries/base/Data/Bifunctor.hs
@@ -20,11 +20,18 @@ module Data.Bifunctor
 import Control.Applicative  ( Const(..) )
 import GHC.Generics ( K1(..) )
 
--- | Formally, the class 'Bifunctor' represents a bifunctor
+-- | A bifunctor is a type constructor that takes 
+-- two type arguments and is a functor in /both/ arguments. That
+-- is, unlike with 'Functor', a type constructor such as 'Either' 
+-- does not need to be partially applied for a 'Bifunctor' 
+-- instance, and the methods in this class permit mapping 
+-- functions over the 'Left' value or the 'Right' value,
+-- or both at the same time. 
+--
+-- Formally, the class 'Bifunctor' represents a bifunctor
 -- from @Hask@ -> @Hask@.
 --
--- Intuitively it is a bifunctor where both the first and second
--- arguments are covariant.
+-- Both the first and second arguments of 'bimap' are covariant. 
 --
 -- You can define a 'Bifunctor' by either defining 'bimap' or by
 -- defining both 'first' and 'second'.
@@ -59,20 +66,47 @@ class Bifunctor p where
     -- | Map over both arguments at the same time.
     --
     -- @'bimap' f g ≡ 'first' f '.' 'second' g@
+    -- 
+    --==== Examples:
+    -- >>> bimap toUpper (+1) ('j', 3)
+    -- ('J',4)
+    -- 
+    -- >>> bimap toUpper (+1) (Left 'j')
+    -- Left 'J'
+    -- 
+    -- >>> bimap toUpper (+1) (Right 3)
+    -- Right 4
     bimap :: (a -> b) -> (c -> d) -> p a c -> p b d
     bimap f g = first f . second g
+
 
     -- | Map covariantly over the first argument.
     --
     -- @'first' f ≡ 'bimap' f 'id'@
+    --
+    --==== Examples:
+    -- >>> first toUpper ('j', 3)
+    -- ('J',3)
+
+    -- >>> first toUpper (Left 'j')
+    -- Left 'J'
     first :: (a -> b) -> p a c -> p b c
     first f = bimap f id
+
 
     -- | Map covariantly over the second argument.
     --
     -- @'second' ≡ 'bimap' 'id'@
+    --
+    --==== Examples:
+    -- >>> second (+1) ('j', 3)
+    -- ('j',4)
+
+    -- >>> second (+1) (Right 3)
+    -- Right 4
     second :: (b -> c) -> p a b -> p a c
     second = bimap id
+
 
 
 -- | @since 4.8.0.0

--- a/libraries/base/Data/Bifunctor.hs
+++ b/libraries/base/Data/Bifunctor.hs
@@ -20,19 +20,19 @@ module Data.Bifunctor
 import Control.Applicative  ( Const(..) )
 import GHC.Generics ( K1(..) )
 
--- | A bifunctor is a type constructor that takes 
+-- | A bifunctor is a type constructor that takes
 -- two type arguments and is a functor in /both/ arguments. That
--- is, unlike with 'Functor', a type constructor such as 'Either' 
--- does not need to be partially applied for a 'Bifunctor' 
--- instance, and the methods in this class permit mapping 
+-- is, unlike with 'Functor', a type constructor such as 'Either'
+-- does not need to be partially applied for a 'Bifunctor'
+-- instance, and the methods in this class permit mapping
 -- functions over the 'Left' value or the 'Right' value,
--- or both at the same time. 
+-- or both at the same time.
 --
 -- Formally, the class 'Bifunctor' represents a bifunctor
 -- from @Hask@ -> @Hask@.
 --
--- Intuitively it is a bifunctor where both the first and second 
--- arguments are covariant. 
+-- Intuitively it is a bifunctor where both the first and second
+-- arguments are covariant.
 --
 -- You can define a 'Bifunctor' by either defining 'bimap' or by
 -- defining both 'first' and 'second'.
@@ -67,14 +67,14 @@ class Bifunctor p where
     -- | Map over both arguments at the same time.
     --
     -- @'bimap' f g ≡ 'first' f '.' 'second' g@
-    -- 
-    --==== Examples:
+    --
+    -- ==== __Examples__
     -- >>> bimap toUpper (+1) ('j', 3)
     -- ('J',4)
-    -- 
+    --
     -- >>> bimap toUpper (+1) (Left 'j')
     -- Left 'J'
-    -- 
+    --
     -- >>> bimap toUpper (+1) (Right 3)
     -- Right 4
     bimap :: (a -> b) -> (c -> d) -> p a c -> p b d
@@ -85,10 +85,10 @@ class Bifunctor p where
     --
     -- @'first' f ≡ 'bimap' f 'id'@
     --
-    --==== Examples:
+    -- ==== __Examples__
     -- >>> first toUpper ('j', 3)
     -- ('J',3)
-    -- 
+    --
     -- >>> first toUpper (Left 'j')
     -- Left 'J'
     first :: (a -> b) -> p a c -> p b c
@@ -99,7 +99,7 @@ class Bifunctor p where
     --
     -- @'second' ≡ 'bimap' 'id'@
     --
-    --==== Examples:
+    -- ==== __Examples__
     -- >>> second (+1) ('j', 3)
     -- ('j',4)
     --

--- a/libraries/base/Data/Bifunctor.hs
+++ b/libraries/base/Data/Bifunctor.hs
@@ -88,7 +88,7 @@ class Bifunctor p where
     --==== Examples:
     -- >>> first toUpper ('j', 3)
     -- ('J',3)
-
+    -- 
     -- >>> first toUpper (Left 'j')
     -- Left 'J'
     first :: (a -> b) -> p a c -> p b c
@@ -102,7 +102,7 @@ class Bifunctor p where
     --==== Examples:
     -- >>> second (+1) ('j', 3)
     -- ('j',4)
-
+    --
     -- >>> second (+1) (Right 3)
     -- Right 4
     second :: (b -> c) -> p a b -> p a c

--- a/libraries/base/Data/Bifunctor.hs
+++ b/libraries/base/Data/Bifunctor.hs
@@ -31,7 +31,8 @@ import GHC.Generics ( K1(..) )
 -- Formally, the class 'Bifunctor' represents a bifunctor
 -- from @Hask@ -> @Hask@.
 --
--- Both the first and second arguments of 'bimap' are covariant. 
+-- Intuitively it is a bifunctor where both the first and second 
+-- arguments are covariant. 
 --
 -- You can define a 'Bifunctor' by either defining 'bimap' or by
 -- defining both 'first' and 'second'.


### PR DESCRIPTION
I thought the `Bifunctor` documentation could use a little expansion and addition of some examples. 