### PR TITLE
escape \ in CallStack example

### DIFF
--- a/libraries/base/GHC/Stack/Types.hs
+++ b/libraries/base/GHC/Stack/Types.hs
@@ -83,7 +83,7 @@ type HasCallStack = (?callStack :: CallStack)
 --
 -- @
 -- errorWithCallStack :: HasCallStack => String -> a
--- errorWithCallStack msg = error (msg ++ "\n" ++ prettyCallStack callStack)
+-- errorWithCallStack msg = error (msg ++ "\\n" ++ prettyCallStack callStack)
 -- @
 --
 -- Thus, if we call @errorWithCallStack@ we will get a formatted call-stack


### PR DESCRIPTION
This example is rendering incorrectly in the [Hadddock HTML](https://hackage.haskell.org/package/base-4.10.0.0/docs/GHC-Stack.html#t:CallStack) (the `"\n"` shows up as `"n"`):

![screenshot-hackage haskell org-2017-11-06-21-21-26-533](https://user-images.githubusercontent.com/399718/32474035-7773d0f0-c338-11e7-933b-e8f540b81eed.png)

I haven't tested this because I don't know how to build GHC yet, but all of my programming experience is telling me the solution *surely* must be to add another backslash?