### PR TITLE
make documentation of atomically more accurate

### DIFF
--- a/libraries/base/GHC/Conc/Sync.hs
+++ b/libraries/base/GHC/Conc/Sync.hs
@@ -716,13 +716,17 @@ unsafeIOToSTM (IO m) = STM m
 
 -- | Perform a series of STM actions atomically.
 --
--- You cannot use 'atomically' inside an 'unsafePerformIO' or 'unsafeInterleaveIO'.
--- Any attempt to do so will result in a runtime error.  (Reason: allowing
--- this would effectively allow a transaction inside a transaction, depending
--- on exactly when the thunk is evaluated.)
+-- Using 'atomically' inside an 'unsafePerformIO' or 'unsafeInterleaveIO'
+-- subverts some of guarantees that STM provides. It makes it possible to
+-- run a transaction inside of another transaction, depending on when the
+-- thunk is evaluated. If a nested transaction is attempted, an exception
+-- is thrown by the runtime. It is possible to safely use 'atomically' inside
+-- 'unsafePerformIO' or 'unsafeInterleaveIO', but the typechecker does not
+-- rule out programs that may attempt nested transactions, meaning that
+-- the programmer must take special care to prevent these.
 --
--- However, see 'newTVarIO', which can be called inside 'unsafePerformIO',
--- and which allows top-level TVars to be allocated.
+-- However, see 'newTVarIO', which can always be safely called inside
+-- 'unsafePerformIO', and which allows top-level TVars to be allocated.
 
 atomically :: STM a -> IO a
 atomically (STM m) = IO (\s -> (atomically# m) s )

--- a/libraries/base/GHC/Conc/Sync.hs
+++ b/libraries/base/GHC/Conc/Sync.hs
@@ -725,8 +725,13 @@ unsafeIOToSTM (IO m) = STM m
 -- rule out programs that may attempt nested transactions, meaning that
 -- the programmer must take special care to prevent these.
 --
--- However, see 'newTVarIO', which can always be safely called inside
--- 'unsafePerformIO', and which allows top-level TVars to be allocated.
+-- However, there are functions for creating transactional variables that
+-- can always be safely called in 'unsafePerformIO'. See: 'newTVarIO',
+-- 'newTChanIO', 'newBroadcastTChanIO', 'newTQueueIO', 'newTBQueueIO',
+-- and 'newTMVarIO'.
+--
+-- Using 'unsafePerformIO' inside of 'atomically' is also dangerous but for
+-- different reasons. See 'unsafeIOToSTM' for more on this.
 
 atomically :: STM a -> IO a
 atomically (STM m) = IO (\s -> (atomically# m) s )


### PR DESCRIPTION
I started a [discussion](https://mail.haskell.org/pipermail/libraries/2017-November/028300.html) on the libraries mailing list about this. Basically, the docs for `atomically` are currently misleading. I noticed this because I in a project I'm working on, I wanted to use `atomically` inside `unsafePerformIO`. I discovered that it did not throw an exception as I expected it to. In this PR, I've updated the docs to reflect, to the best of my understanding, the expectations a user can have when using `atomically` in `unsafePerformIO`.