### PR TITLE
Only look for locales of the form LL.VV

### DIFF
--- a/testsuite/driver/runtests.py
+++ b/testsuite/driver/runtests.py
@@ -151,7 +151,7 @@ else:
     h.close()
     if v == '':
         # We don't, so now see if 'locale -a' works
-        h = os.popen('locale -a', 'r')
+        h = os.popen('locale -a | grep -F .', 'r')
         v = h.read()
         h.close()
         if v != '':


### PR DESCRIPTION
because in recent RHEL7 suddenly locales like `bokmål` pop up, which screw up reading-in of ASCII strings a line later. This additional criterion reliably eliminates those unicode characters.