### PR TITLE
Prevent "C--" translating to "C<endash>" in the User's Guide.

### DIFF
--- a/docs/users_guide/debug-info.rst
+++ b/docs/users_guide/debug-info.rst
@@ -268,10 +268,10 @@ GHC may produce the following standard DIEs in the ``.debug_info`` section,
   Represents a compilation unit (e.g. a Haskell module).
 
 ``DW_TAG_subprogram``
-  Represents a C-- top-level basic block.
+  Represents a C-\\- top-level basic block.
 
 ``DW_TAG_lexical_block``
-  Represents a C-- basic block. Note that this is a slight departure from the
+  Represents a C-\\- basic block. Note that this is a slight departure from the
   intended meaning of this DIE type as it does not necessarily reflect
   lexical scope in the source program.
 

--- a/docs/users_guide/debugging.rst
+++ b/docs/users_guide/debugging.rst
@@ -352,90 +352,90 @@ These flags dump various phases of GHC's STG pipeline.
     Show the output of the intermediate STG-to-STG pass. (*lots* of output!)
 
 
-C-- representation
-~~~~~~~~~~~~~~~~~~
+C-\\- representation
+~~~~~~~~~~~~~~~~~~~~
 
-These flags dump various phases of GHC's C-- pipeline.
+These flags dump various phases of GHC's C-\\- pipeline.
 
 .. ghc-flag:: -ddump-cmm-verbose
-    :shortdesc: Show output from each C-- pipeline pass
+    :shortdesc: Show output from each C-\\- pipeline pass
     :type: dynamic
 
-    Dump output from all C-- pipeline stages. In case of
+    Dump output from all C-\\- pipeline stages. In case of
     ``.cmm`` compilation this also dumps the result of
     file parsing.
 
 .. ghc-flag:: -ddump-cmm-from-stg
-    :shortdesc: Dump STG-to-C-- output
+    :shortdesc: Dump STG-to-C-\\- output
     :type: dynamic
 
-    Dump the result of STG-to-C-- conversion
+    Dump the result of STG-to-C-\\- conversion
 
 .. ghc-flag:: -ddump-cmm-raw
-    :shortdesc: Dump raw C--
+    :shortdesc: Dump raw C-\\-
     :type: dynamic
 
-    Dump the “raw” C--.
+    Dump the “raw” C-\\-.
 
 .. ghc-flag:: -ddump-cmm-cfg
-    :shortdesc: Dump the results of the C-- control flow optimisation pass.
+    :shortdesc: Dump the results of the C-\\- control flow optimisation pass.
     :type: dynamic
 
-    Dump the results of the C-- control flow optimisation pass.
+    Dump the results of the C-\\- control flow optimisation pass.
 
 .. ghc-flag:: -ddump-cmm-cbe
     :shortdesc: Dump the results of common block elimination
     :type: dynamic
 
-    Dump the results of the C-- Common Block Elimination (CBE) pass.
+    Dump the results of the C-\\- Common Block Elimination (CBE) pass.
 
 .. ghc-flag:: -ddump-cmm-switch
     :shortdesc: Dump the results of switch lowering passes
     :type: dynamic
 
-    Dump the results of the C-- switch lowering pass.
+    Dump the results of the C-\\- switch lowering pass.
 
 .. ghc-flag:: -ddump-cmm-proc
     :shortdesc: Dump the results of proc-point analysis
     :type: dynamic
 
-    Dump the results of the C-- proc-point analysis pass.
+    Dump the results of the C-\\- proc-point analysis pass.
 
 .. ghc-flag:: -ddump-cmm-sp
-    :shortdesc: Dump the results of the C-- stack layout pass.
+    :shortdesc: Dump the results of the C-\\- stack layout pass.
     :type: dynamic
 
-    Dump the results of the C-- stack layout pass.
+    Dump the results of the C-\\- stack layout pass.
 
 .. ghc-flag:: -ddump-cmm-sink
-    :shortdesc: Dump the results of the C-- sinking pass.
+    :shortdesc: Dump the results of the C-\\- sinking pass.
     :type: dynamic
 
-    Dump the results of the C-- sinking pass.
+    Dump the results of the C-\\- sinking pass.
 
 .. ghc-flag:: -ddump-cmm-caf
-    :shortdesc: Dump the results of the C-- CAF analysis pass.
+    :shortdesc: Dump the results of the C-\\- CAF analysis pass.
     :type: dynamic
 
-    Dump the results of the C-- CAF analysis pass.
+    Dump the results of the C-\\- CAF analysis pass.
 
 .. ghc-flag:: -ddump-cmm-procmap
-    :shortdesc: Dump the results of the C-- proc-point map pass.
+    :shortdesc: Dump the results of the C-\\- proc-point map pass.
     :type: dynamic
 
-    Dump the results of the C-- proc-point map pass.
+    Dump the results of the C-\\- proc-point map pass.
 
 .. ghc-flag:: -ddump-cmm-split
-    :shortdesc: Dump the results of the C-- proc-point splitting pass.
+    :shortdesc: Dump the results of the C-\\- proc-point splitting pass.
     :type: dynamic
 
-    Dump the results of the C-- proc-point splitting pass.
+    Dump the results of the C-\\- proc-point splitting pass.
 
 .. ghc-flag:: -ddump-cmm-info
-    :shortdesc: Dump the results of the C-- info table augmentation pass.
+    :shortdesc: Dump the results of the C-\\- info table augmentation pass.
     :type: dynamic
 
-    Dump the results of the C-- info table augmentation pass.
+    Dump the results of the C-\\- info table augmentation pass.
 
 .. ghc-flag:: -ddump-cmm-cps
     :shortdesc: Dump the results of the CPS pass
@@ -444,10 +444,10 @@ These flags dump various phases of GHC's C-- pipeline.
     Dump the results of the CPS pass.
 
 .. ghc-flag:: -ddump-cmm
-    :shortdesc: Dump the final C-- output
+    :shortdesc: Dump the final C-\\- output
     :type: dynamic
 
-    Dump the result of the C-- pipeline processing
+    Dump the result of the C-\\- pipeline processing
 
 
 
@@ -466,20 +466,20 @@ Native code generator
 ~~~~~~~~~~~~~~~~~~~~~
 
 These flags dump various stages of the :ref:`native code generator's
-<native-code-gen>` pipeline, which starts with C-- and produces native
+<native-code-gen>` pipeline, which starts with C-\\- and produces native
 assembler.
 
 .. ghc-flag:: -ddump-opt-cmm
-    :shortdesc: Dump the results of C-- to C-- optimising passes
+    :shortdesc: Dump the results of C-\\- to C-\\- optimising passes
     :type: dynamic
 
-    Dump the results of C-- to C-- optimising passes performed by the NCG.
+    Dump the results of C-\\- to C-\\- optimising passes performed by the NCG.
 
 .. ghc-flag:: -ddump-asm-native
     :shortdesc: Dump initial assembly
     :type: dynamic
 
-    Dump the initial assembler output produced from C--.
+    Dump the initial assembler output produced from C-\\-.
 
 .. ghc-flag:: -ddump-asm-liveness
     :shortdesc: Dump assembly augmented with register liveness
@@ -700,10 +700,10 @@ Checking for consistency
     Ditto for STG level. (note: currently doesn't work).
 
 .. ghc-flag:: -dcmm-lint
-    :shortdesc: C-- pass sanity checking
+    :shortdesc: C-\\- pass sanity checking
     :type: dynamic
 
-    Ditto for C-- level.
+    Ditto for C-\\- level.
 
 .. ghc-flag:: -fllvm-fill-undef-with-garbage
     :shortdesc: Intruct LLVM to fill dead STG registers with garbage

--- a/docs/users_guide/extending_ghc.rst
+++ b/docs/users_guide/extending_ghc.rst
@@ -179,7 +179,7 @@ GHC's intermediate language, Core. Plugins are suitable for experimental
 analysis or optimization, and require no changes to GHC's source code to
 use.
 
-Plugins cannot optimize/inspect C--, nor can they implement things like
+Plugins cannot optimize/inspect C-\\-, nor can they implement things like
 parser/front-end modifications like GCC, apart from limited changes to
 the constraint solver. If you feel strongly that any of these
 restrictions are too onerous,


### PR DESCRIPTION
i.e. escape "--" so that it doesn't translate to an "en dash" character. I did this by providing a `|Cmm|` substitution.

Note: I would have preferred to add the `|Cmm|` substitution in a single place — either `conf.py` in the existing `rst_prolog`, `rst_epilog`, or alternatively an included file. However, each of these options provoked a runtime exception from docutils (on Sphinx 1.6.5). Therefore, I've defined `|Cmm|` at the bottom of the 3 affected files.