### PR TITLE
Increase the amount of parallelism in circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
       name: submodules
       command: .circleci/fetch-submodules.sh
   - &buildenv
-    THREADS: 8
+    THREADS: 9
     SKIP_PERF_TESTS: YES
     VERBOSE: 2
   - &boot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
       name: submodules
       command: .circleci/fetch-submodules.sh
   - &buildenv
-    THREADS: 3
+    THREADS: 8
     SKIP_PERF_TESTS: YES
     VERBOSE: 2
   - &boot


### PR DESCRIPTION
This almost halves the time of the build. For some reason circleci was not configured to use all the 8 cpus of the xlarge containers.
https://circleci.com/gh/tweag/ghc/205