### PR TITLE
Add a job for 32 bit Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ aliases:
     run:
       name: Configure
       command: ./configure
+  - &configure_unix_32
+    run:
+      name: Configure
+      command: |
+        setarch i386 ./configure --with-ghc=/opt/ghc-i386/8.2.2/bin/ghc
   - &configure_bsd
     run:
       name: Configure
@@ -207,6 +212,24 @@ jobs:
       - *make
       - *test
 
+  "validate-i386-linux":
+    resource_class: xlarge
+    docker:
+      - image: ghcci/i386-linux:0.0.1
+    environment:
+      <<: *buildenv
+    steps:
+      - checkout
+      - *prepare
+      - *submodules
+      - *boot
+      - *configure_unix_32
+      - *make
+      - *test
+      - *bindist
+      - *collectartifacts
+      - *storeartifacts
+
 workflows:
   version: 2
   validate:
@@ -216,6 +239,7 @@ workflows:
     # - validate-x86_64-freebsd
     - validate-x86_64-darwin
     - validate-x86_64-linux-llvm
+    - validate-i386-linux
     - validate-hadrian-x86_64-linux
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,6 @@ version: 2
 aliases:
   - &defaults
     working_directory: ~/ghc
-
-  # Make sure we have proper openssh before checkout: CircleCI git
-  # does not check the repository out properly without it and also
-  # takes 20 times longer than it should be.
-  - &precheckout
-    run:
-      name: Install OpenSSH client
-      command: |
-        apt-get update -qq
-        apt-get install -qy openssh-client
   - &prepare
     run:
       name: prepare-system
@@ -92,11 +82,10 @@ jobs:
   "validate-x86_64-linux":
     resource_class: xlarge
     docker:
-      - image: haskell:8.2
+      - image: mrkkrp/ghcci-x86_64-linux:0.0.4
     environment:
       <<: *buildenv
     steps:
-      - *precheckout
       - checkout
       - *prepare
       - *submodules
@@ -111,12 +100,11 @@ jobs:
   "validate-x86_64-freebsd":
     resource_class: xlarge
     docker:
-      - image: tweag/toolchain-x86_64-freebsd
+      - image: mrkkrp/ghcci-x86_64-freebsd
     environment:
       TARGET: FreeBSD
       <<: *buildenv
     steps:
-      - *precheckout
       - checkout
       - *prepare
       - *submodules
@@ -152,11 +140,10 @@ jobs:
   "validate-hadrian-x86_64-linux":
     resource_class: xlarge
     docker:
-      - image: haskell:8.2
+      - image: mrkkrp/ghcci-x86_64-linux:0.0.4
     environment:
       <<: *buildenv
     steps:
-      - *precheckout
       - checkout
       - *prepare
       - *submodules
@@ -167,11 +154,10 @@ jobs:
   "validate-x86_64-linux-unreg":
     resource_class: xlarge
     docker:
-      - image: haskell:8.2
+      - image: mrkkrp/ghcci-x86_64-linux:0.0.4
     environment:
       <<: *buildenv
     steps:
-      - *precheckout
       - checkout
       - *prepare
       - *submodules
@@ -183,7 +169,7 @@ jobs:
   "validate-x86_64-linux-llvm":
     resource_class: xlarge
     docker:
-      - image: haskell:8.2
+      - image: mrkkrp/ghcci-x86_64-linux:0.0.4
     environment:
       <<: *buildenv
       BUILD_FLAVOUR: perf-llvm
@@ -191,15 +177,11 @@ jobs:
       - run:
           name: Install LLVM
           command: |
-            apt-get update
-            apt-get install -y curl xz-utils
             curl http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-x86_64-linux-gnu-debian8.tar.xz | tar -xJC ..
-            # See https://discuss.circleci.com/t/how-to-add-a-path-to-path-in-circle-2-0/11554/3
             echo "export PATH=`pwd`/../clang+llvm-5.0.0-x86_64-linux-gnu-debian8/bin:\$PATH" >> $BASH_ENV
       - run:
           name: Verify that llc works
           command: llc
-      - *precheckout
       - checkout
       - *prepare
       - *submodules
@@ -212,12 +194,11 @@ jobs:
   "validate-x86_64-linux-debug":
     resource_class: xlarge
     docker:
-      - image: haskell:8.2
+      - image: mrkkrp/ghcci-x86_64-linux:0.0.4
     environment:
       BUILD_FLAVOUR: devel2
       <<: *buildenv
     steps:
-      - *precheckout
       - checkout
       - *prepare
       - *submodules

--- a/.circleci/images/i386-linux/Dockerfile
+++ b/.circleci/images/i386-linux/Dockerfile
@@ -1,0 +1,30 @@
+# This Dockerfile tries to replicate haskell:8.2 a bit, but it does so on
+# top of i368/debian:jessie instead of debian:jessie because I had troubles
+# making i386 GHC bindist working there.
+
+FROM i386/debian:jessie
+
+ENV LANG C.UTF-8
+
+# Install the necessary packages, including HVR stuff.
+RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main' > /etc/apt/sources.list.d/ghc.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286
+RUN apt-get update -qq
+RUN apt-get install -qy git make automake autoconf gcc perl python3 texinfo xz-utils lbzip2 bzip2 patch openssh-client sudo curl zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++ cabal-install-2.0 ghc-8.2.2 happy-1.19.5 alex-3.1.7
+ENV PATH /opt/cabal/2.0/bin:/opt/ghc/8.2.2/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.7/bin:$PATH
+
+# Get i386 GHC bindist for 32 bit CI builds.
+RUN cd /tmp && curl https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-i386-deb8-linux.tar.xz | tar -Jx
+RUN cd /tmp/ghc-8.2.2 && setarch i386 ./configure --prefix=/opt/ghc-i386/8.2.2 CFLAGS=-m32 --target=i386-unknown-linux --build=i386-unknown-linux --host=i386-unknown-linux
+RUN cd /tmp/ghc-8.2.2 && make install
+RUN rm -rf /tmp/ghc-8.2.2
+ENV PATH /opt/ghc-i386/8.2.2/bin:$PATH
+
+# Create a normal user.
+RUN adduser ghc --gecos "GHC builds" --disabled-password
+RUN echo "ghc ALL = NOPASSWD : ALL" > /etc/sudoers.d/ghc
+USER ghc
+
+WORKDIR /home/ghc/
+
+CMD ["bash"]

--- a/.circleci/images/x86_64-linux/Dockerfile
+++ b/.circleci/images/x86_64-linux/Dockerfile
@@ -1,3 +1,16 @@
 FROM haskell:8.2
-RUN adduser ghc --gecos 'GHC builds' --disabled-password
+
+# Make sure we have proper openssh before checkout: CircleCI git
+# does not check the repository out properly without it and also
+# takes 20 times longer than it should be.
+RUN apt-get update -qq
+RUN apt-get install -qy git make automake autoconf gcc perl python3 texinfo xz-utils lbzip2 patch openssh-client sudo -qq curl
+
+# Create a normal user.
+RUN adduser ghc --gecos "GHC builds" --disabled-password
+RUN echo "ghc ALL = NOPASSWD : ALL" > /etc/sudoers.d/ghc
 USER ghc
+
+WORKDIR /home/ghc/
+
+CMD ["bash"]

--- a/.circleci/prepare-system.sh
+++ b/.circleci/prepare-system.sh
@@ -42,23 +42,25 @@ case "$(uname)" in
         fail "TARGET=$target not supported"
       fi
     else
-      # assuming Ubuntu
-      apt-get install -qy git make automake autoconf gcc perl python3 texinfo xz-utils lbzip2 patch
       cabal update
-      cabal install --reinstall hscolour --index-state=$hackage_index_state
+      cabal install --reinstall hscolour
+      sudo ln -s /home/ghc/.cabal/bin/HsColour /usr/local/bin/HsColour || true
     fi
     ;;
   Darwin)
     if [[ -n ${TARGET:-} ]]; then
       fail "uname=$(uname) not supported for cross-compilation"
     fi
-    brew install ghc cabal-install python3 ncurses gmp
+    # It looks like we already have python2 here and just installing python3
+    # does not work.
+    brew upgrade python
+    brew install ghc cabal-install ncurses gmp
     cabal update
     cabal install --reinstall alex happy haddock hscolour --index-state=$hackage_index_state
     # put them on the $PATH, don't fail if already installed
     ln -s $HOME/.cabal/bin/alex /usr/local/bin/alex || true
     ln -s $HOME/.cabal/bin/happy /usr/local/bin/happy || true
-    ln -s $HOME/.cabal/bin/hscolour /usr/local/bin/hscolour || true
+    ln -s $HOME/.cabal/bin/HsColour /usr/local/bin/HsColour || true
     ;;
   *)
     fail "uname=$(uname) not supported"


### PR DESCRIPTION
Ticket: https://ghc.haskell.org/trac/ghc/ticket/14598.
Patch (should be discarded if we merge this): https://phabricator.haskell.org/D4425.

It's best to merge #104 first, because:

1. The job required a custom docker image, because the existing image `haskell:8.2` did not work (`./configure` failed, and even if I could omit some options and make it work then `make` failed in all cases), so I had to create something similar based on `i368/debian:jessie` which worked. And while I was at it, I decided to make it properly with a non-root user.

2. Thus `system-prepare.sh` also should use `sudo` and so it makes sense to start this branch from `do-not-run-on-circle-ci-as-root`.

If there is a good reason, I could rebase against master and make it work without #104 somehow.

----

So this builds but a good number of tests fails (at least locally, still waiting for it to finish on CI). Fixing all those tests is for another ticket, probably.

```
SUMMARY for test run started at Mon Mar  5 13:39:08 2018 UTC
 0:44:01 spent to go through
    6273 total tests, which gave rise to
   24698 test cases, of which
   18122 were skipped

      56 had missing libraries
    6202 expected passes
      94 expected failures

       2 caused framework failures
      37 caused framework warnings
       0 unexpected passes
     222 unexpected failures
       0 unexpected stat failures
```