### PR TITLE
Fix typo in user guide about ConstraintKinds

### DIFF
--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -9442,7 +9442,7 @@ The following things have kind ``Constraint``:
 -  Anything whose form is not yet known, but the user has declared to
    have kind ``Constraint`` (for which they need to import it from
    ``GHC.Exts``). So for example
-   ``type Foo (f :: \* -> Constraint) = forall b. f b => b -> b``
+   ``type Foo (f :: * -> Constraint) = forall b. f b => b -> b``
    is allowed, as well as examples involving type families: ::
 
        type family Typ a b :: Constraint


### PR DESCRIPTION
The backslash currently in this type signature makes no sense. Without it, the example is fine.

Maybe you even want to fix this typo in the current version, I have no idea how the GHC repository is structured regarding releases and/or back-ports etc., or what your standard procedure with typos is anyways ;-)