### PR TITLE
Full AppVeyor build with tests

### DIFF
--- a/.appveyor.sh
+++ b/.appveyor.sh
@@ -1,8 +1,8 @@
 # Configure the environment
 MSYSTEM=MINGW64
-THREADS=3
+THREADS=9
 SKIP_PERF_TESTS=YES
-BUILD_FLAVOUR=quick
+BUILD_FLAVOUR=
 source /etc/profile || true # a terrible, terrible workaround for msys2 brokenness
 
 # Don't set -e until after /etc/profile is sourced
@@ -11,45 +11,27 @@ cd $APPVEYOR_BUILD_FOLDER
 
 case "$1" in
     "prepare")
-        # Bring msys up-to-date
-        # However, we current don't do this: generally one must restart all
-        # msys2 processes when updating the msys2 runtime, which this may do. We can't
-        # easily do this and therefore do simply don't update.
-        #pacman --noconfirm -Syuu
-
-        # Install basic build dependencies
-        pacman --noconfirm -S --needed git tar bsdtar binutils autoconf make xz curl libtool automake python python2 p7zip patch mingw-w64-$(uname -m)-python3-sphinx mingw-w64-$(uname -m)-tools-git
-
         # Prepare the tree
         git config remote.origin.url git://github.com/ghc/ghc.git
         git config --global url."git://github.com/ghc/packages-".insteadOf git://github.com/ghc/packages/
         git submodule init
         git submodule --quiet update --recursive
-
-        # Install build dependencies
-        wget -q -O - https://downloads.haskell.org/~ghc/8.2.1/ghc-8.2.1-x86_64-unknown-mingw32.tar.xz | tar -xJ -C /mingw64 --strip-components=1
-        mkdir -p /usr/local/bin
-        wget -q -O - https://www.haskell.org/cabal/release/cabal-install-1.24.0.0/cabal-install-1.24.0.0-x86_64-unknown-mingw32.zip | bsdtar -xzf- -C /usr/local/bin
-        cabal update
-        cabal install -j --prefix=/usr/local alex happy
         ;;
-
     "build")
         # Build the compiler
         ./boot
-        ./configure --enable-tarballs-autodownload
         cat <<EOF >> mk/build.mk
         BuildFlavour=$BUILD_FLAVOUR
         ifneq "\$(BuildFlavour)" ""
         include mk/flavours/\$(BuildFlavour).mk
         endif
 EOF
+        ./configure --enable-tarballs-autodownload
         make -j$THREADS
         ;;
 
     "test")
-        # This does not finish in time.
-        # make fasttest THREADS=$THREADS
+        make test THREADS=$THREADS
         make binary-dist
         7z a ghc-windows.zip *.tar.xz
         ;;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 version: "{build}"
+build_cloud: ghc-gce-cloud
+image: GHC-GCE
 
 build:
   verbosity: normal
@@ -12,7 +14,6 @@ environment:
     MSYSTEM: MINGW64
     BIT: 64
 
-os: Visual Studio 2015
 deploy: off
 
 install:


### PR DESCRIPTION
We have succeeded in running full build with tests on AppVeyor.

Times:

* Only build (default build flavor): 1h 53min.
* Build with fasttests: 2h 15min.
* Build with tests: 2h 28min (this PR).

This is virtually the same times we've got for `validate-x86_64-linux-llvm` job in Circle CI, so I guess it's an acceptable result.

Just merging this PR is not sufficient of course because it's necessary to setup things in your AppVeyor account so it'll use private build cloud we've got now with image I've prepared. If you add me as an admin to GHC AppVeyor account I can handle all of this.

Some tests fail: https://ci.appveyor.com/project/mboes/ghc/build/129, but that's another story.

@bgamari Let me know what you think.