### PR TITLE
Add a job running on Fedora

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,24 @@ jobs:
       - *collectartifacts
       - *storeartifacts
 
+  "validate-x86_64-fedora":
+    resource_class: xlarge
+    docker:
+      - image: ghcci/x86_64-linux-fedora:0.0.2
+    environment:
+      <<: *buildenv
+    steps:
+      - checkout
+      - *prepare
+      - *submodules
+      - *boot
+      - *configure_unix
+      - *make
+      - *test
+      - *bindist
+      - *collectartifacts
+      - *storeartifacts
+
 workflows:
   version: 2
   validate:
@@ -241,6 +259,7 @@ workflows:
     - validate-x86_64-linux-llvm
     - validate-i386-linux
     - validate-hadrian-x86_64-linux
+    - validate-x86_64-fedora
 
   nightly:
     triggers:

--- a/.circleci/images/x86_64-linux-fedora/Dockerfile
+++ b/.circleci/images/x86_64-linux-fedora/Dockerfile
@@ -1,0 +1,26 @@
+FROM fedora:27
+
+ENV LANG C.UTF-8
+
+RUN dnf -y install coreutils binutils which git make automake autoconf gcc perl python3 texinfo xz lbzip2 patch openssh-clients sudo curl zlib-devel sqlite ncurses-compat-libs gmp-devel ncurses-devel gcc-c++ findutils
+
+# Install GHC and cabal
+RUN cd /tmp && curl https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-deb8-linux.tar.xz | tar -Jx
+RUN cd /tmp/ghc-8.2.2 && ./configure --prefix=/opt/ghc/8.2.2
+RUN cd /tmp/ghc-8.2.2 && make install
+RUN mkdir -p /opt/cabal/bin
+RUN cd /opt/cabal/bin && curl https://www.haskell.org/cabal/release/cabal-install-2.0.0.1/cabal-install-2.0.0.1-x86_64-unknown-linux.tar.gz | tar -zx
+ENV PATH /opt/ghc/8.2.2/bin:/opt/cabal/bin:$PATH
+
+# Create a normal user.
+RUN adduser ghc --comment "GHC builds"
+RUN echo "ghc ALL = NOPASSWD : ALL" > /etc/sudoers.d/ghc
+USER ghc
+WORKDIR /home/ghc/
+
+# Install Alex, Happy, and HsColor with Cabal
+RUN cabal update
+RUN cabal install alex happy hscolour
+ENV PATH /home/ghc/.cabal/bin:$PATH
+
+CMD ["bash"]


### PR DESCRIPTION
This adds a job running on Fedora 26. Trac ticket: https://ghc.haskell.org/trac/ghc/ticket/14949.

Can you clarify what you mean by

> In principle we only need to produce one bindist per combination

Do you mean that we should add one job per line in [this table](https://ghc.haskell.org/trac/ghc/wiki/Platforms/Linux), but if so, maybe it's too many? If "per combination" means that we we should add even more jobs, then I'm not sure it's a good idea.

Currently I see that bindists include the following:

OS | Job
----|-----
Linux (x86) | `validate-i386-linux`
Linux (x64_64) | `validate-x86_64-linux`
Linux (ARMv7) | ?
Linux (AArch64) | ?
Windows (x86) | ?
Windows (x86_64) | AppVeyor build
Mac OS X (x86_64) | `validate-x86_64-darwin`

[Taken from here](https://www.haskell.org/ghc/download_ghc_8_4_1.html). So I don't understand why we want to generate artifacts on Fedora. GHC built on Debian worked there fine. I'd expect that we need to add jobs that are missing, i.e. that are marked with ? in the table above if we're to generate all bindists on CI.