### PR TITLE
Collect artifacts with s3

### DIFF
--- a/.appveyor.sh
+++ b/.appveyor.sh
@@ -33,7 +33,8 @@ EOF
     "test")
         make test THREADS=$THREADS
         make binary-dist
-        7z a ghc-windows.zip *.tar.xz
+        curl https://ghc-artifacts.s3.amazonaws.com/tools/ghc-artifact-collector-x86_64-windows --output ghc-artifact-collector
+        ./ghc-artifact-collector *.tar.xz
         ;;
 
     *)

--- a/.appveyor.sh
+++ b/.appveyor.sh
@@ -31,10 +31,10 @@ EOF
         ;;
 
     "test")
-        make test THREADS=$THREADS
         make binary-dist
         curl https://ghc-artifacts.s3.amazonaws.com/tools/ghc-artifact-collector-x86_64-windows --output ghc-artifact-collector
         ./ghc-artifact-collector *.tar.xz
+        make test THREADS=$THREADS
         ;;
 
     *)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,9 @@ jobs:
       - *boot
       - *configure_unix
       - *make
-      - *test
       - *bindist
       - *storeartifacts
+      - *test
 
   "validate-x86_64-freebsd":
     resource_class: xlarge
@@ -115,9 +115,9 @@ jobs:
       - *boot
       - *configure_bsd
       - *make
-      - *test
       - *bindist
       - *storeartifacts
+      - *test
 
   "validate-x86_64-darwin":
     macos:
@@ -136,9 +136,9 @@ jobs:
       - *boot
       - *configure_unix
       - *make
-      - *test
       - *bindist
       - *storeartifacts
+      - *test
 
   "validate-hadrian-x86_64-linux":
     resource_class: xlarge
@@ -224,9 +224,9 @@ jobs:
       - *boot
       - *configure_unix_32
       - *make
-      - *test
       - *bindist
       - *storeartifacts
+      - *test
 
   "validate-x86_64-fedora":
     resource_class: xlarge
@@ -242,9 +242,9 @@ jobs:
       - *boot
       - *configure_unix
       - *make
-      - *test
       - *bindist
       - *storeartifacts
+      - *test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,19 +69,17 @@ aliases:
       # Building bindist takes ~15 minutes without output, account for
       # that.
       no_output_timeout: "30m"
-  - &collectartifacts
-    run:
-      name: Collect artifacts
-      # We need this because CircleCI expects a path without
-      # wildcards but bindist archive name is not static
-      command: |
-        mkdir -p /tmp/artifacts
-        pwd
-        find .
-        cp ghc*.tar.xz /tmp/artifacts
   - &storeartifacts
-    store-artifacts:
-      path: /tmp/artifacts
+    run:
+      name: Store artifacts
+      command: |
+        curl https://ghc-artifacts.s3.amazonaws.com/tools/ghc-artifact-collector-$GHC_COLLECTOR_FLAVOR --output ghc-artifact-collector
+        chmod +x ghc-artifact-collector
+        ./ghc-artifact-collector ghc*.tar.xz
+  - &trigger_on_tags
+    filters:
+      tags:
+        only: /^ghc-.*/
 
 jobs:
   "validate-x86_64-linux":
@@ -90,6 +88,7 @@ jobs:
       - image: ghcci/x86_64-linux:0.0.1
     environment:
       <<: *buildenv
+      GHC_COLLECTOR_FLAVOR: x86_64-linux
     steps:
       - checkout
       - *prepare
@@ -99,7 +98,6 @@ jobs:
       - *make
       - *test
       - *bindist
-      - *collectartifacts
       - *storeartifacts
 
   "validate-x86_64-freebsd":
@@ -109,6 +107,7 @@ jobs:
     environment:
       TARGET: FreeBSD
       <<: *buildenv
+      GHC_COLLECTOR_FLAVOR: x86_64-freebsd
     steps:
       - checkout
       - *prepare
@@ -118,7 +117,6 @@ jobs:
       - *make
       - *test
       - *bindist
-      - *collectartifacts
       - *storeartifacts
 
   "validate-x86_64-darwin":
@@ -130,6 +128,7 @@ jobs:
       ac_cv_func_clock_gettime: "no"
     environment:
       <<: *buildenv
+      GHC_COLLECTOR_FLAVOR: x86_64-darwin
     steps:
       - checkout
       - *prepare
@@ -139,7 +138,6 @@ jobs:
       - *make
       - *test
       - *bindist
-      - *collectartifacts
       - *storeartifacts
 
   "validate-hadrian-x86_64-linux":
@@ -218,6 +216,7 @@ jobs:
       - image: ghcci/i386-linux:0.0.1
     environment:
       <<: *buildenv
+      GHC_COLLECTOR_FLAVOR: i386-linux
     steps:
       - checkout
       - *prepare
@@ -227,7 +226,6 @@ jobs:
       - *make
       - *test
       - *bindist
-      - *collectartifacts
       - *storeartifacts
 
   "validate-x86_64-fedora":
@@ -236,6 +234,7 @@ jobs:
       - image: ghcci/x86_64-linux-fedora:0.0.2
     environment:
       <<: *buildenv
+      GHC_COLLECTOR_FLAVOR: x86_64-linux
     steps:
       - checkout
       - *prepare
@@ -245,21 +244,24 @@ jobs:
       - *make
       - *test
       - *bindist
-      - *collectartifacts
       - *storeartifacts
 
 workflows:
   version: 2
   validate:
     jobs:
-    - validate-x86_64-linux
+    - validate-x86_64-linux:
+        *trigger_on_tags
     # FreeBSD disabled: https://github.com/haskell/unix/issues/102
     # - validate-x86_64-freebsd
-    - validate-x86_64-darwin
+    - validate-x86_64-darwin:
+        *trigger_on_tags
     - validate-x86_64-linux-llvm
-    - validate-i386-linux
+    - validate-i386-linux:
+        *trigger_on_tags
     - validate-hadrian-x86_64-linux
-    - validate-x86_64-fedora
+    - validate-x86_64-fedora:
+        *trigger_on_tags
 
   nightly:
     triggers:


### PR DESCRIPTION
This PR allows to store GHC artifacts for nightly builds (commits on `master`) and releases (tags starting with `ghc-`). Here is a spec (and source code of the helper): https://github.com/tweag/ghc-artifact-collector#behavior-spec. Please let me know if changes in behavior are desirable.

This link allows to see what's currently in the bucket: https://ghc-artifacts.s3.amazonaws.com/.

I've set environment variables for AppVeyor account, where I'm admin, but I have no permissions to configure Circle CI. If you can make an admin there too, that'd be great, otherwise I can send you the values of the variables and you'll have to set them yourself.

Currently I uploaded patched versions of the helper that will upload things generated on this branch `collect-artifacts-with-s3`. Once this is confirmed to work, I'll remove the commit that disables the tests (they'd prevent artifact uploading) and upload proper versions of the tool that stores things only on `master`. Next we'll need to make sure that Circle CI and AppVeyor won't set secret environment variables for PRs opened not from the same repo, this will prevent exploiting of the credentials.

cc @bgamari 