### PR TITLE
docs(Data.Function): fix and augment `on` annotation

### DIFF
--- a/libraries/base/Data/Function.hs
+++ b/libraries/base/Data/Function.hs
@@ -50,18 +50,21 @@ infixl 1 &
 fix :: (a -> a) -> a
 fix f = let x = f x in x
 
--- | @((==) \`on\` f) x y = f x == f y@
+-- | @'on' b u x y@ runs the binary function `b` /on/ the results of applying unary function `u` to two arguments `x` and `y`. From the opposite perspective, it transforms two inputs and combines the outputs.
+--
+-- @((+) \``on`\` f) x y = f x + f y@
 --
 -- Typical usage: @'Data.List.sortBy' ('compare' \`on\` 'fst')@.
-
+--
 -- Algebraic properties:
 --
--- * @(*) \`on\` 'id' = (*)@ (if @(*) &#x2209; {&#x22a5;, 'const' &#x22a5;}@)
+-- * @(*) \`on\` 'id' = (*) -- (if (*) &#x2209; {&#x22a5;, 'const' &#x22a5;})@
 --
 -- * @((*) \`on\` f) \`on\` g = (*) \`on\` (f . g)@
 --
 -- * @'flip' on f . 'flip' on g = 'flip' on (g . f)@
-
+on :: (b -> b -> c) -> (a -> b) -> a -> a -> c
+(.*.) `on` f = \x y -> f x .*. f y
 -- Proofs (so that I don't have to edit the test-suite):
 
 --   (*) `on` id
@@ -101,9 +104,6 @@ fix f = let x = f x in x
 --   (\h (*) -> (*) `on` h) (g . f)
 -- =
 --   flip on (g . f)
-
-on :: (b -> b -> c) -> (a -> b) -> a -> a -> c
-(.*.) `on` f = \x y -> f x .*. f y
 
 
 -- | '&' is a reverse application operator.  This provides notational


### PR DESCRIPTION
_First GHC PR! 😃_

---

The [current docs](https://hackage.haskell.org/package/base-4.11.0.0/docs/Data-Function.html#v:on) on Hackage for `Data.Function.on` are empty (apart from type signature). However, the [source code](https://hackage.haskell.org/package/base-4.11.0.0/docs/src/Data.Function.html#on) reveals some helpful comments. The problem was newlines between comments preventing Haddock from associating the annotation to the function.

This PR:

* Fixes the newline issue so annotations appear
* Adds a prose comment explaining `on`'s use case
* Changes one example to use `(+)` instead of `(==)` as the former has higher "mental contrast" with definition (`=`), making the example code arguably clearer for Haskell neophytes
* Alters the formatting of one of the algebraic properties, as otherwise it wasn't wrapped in a `pre` tag, rendering it visually different (and confusing) compared to the other properties
* Moves the proofs below the source code, removing them from the visible documentation

The last point there is the one which I am most uncertain on, as it was not clear if the proofs were intended to be readable as documentation or not. I could reformat them and make them part of the readable documentation if that is preferred.

Here is an "after" shot as rendered locally by Haddock:

<img width="657" alt="screenshot-on" src="https://user-images.githubusercontent.com/7230206/38457867-1663ab34-3a64-11e8-9a53-115e1c2bc5dc.png">