### PR TITLE
Fix markup in the UNPACK pragma section of the user's guide.

### DIFF
--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -14406,11 +14406,8 @@ See also the :ghc-flag:`-funbox-strict-fields` flag, which essentially has the
 effect of adding ``{-# UNPACK #-}`` to every strict constructor field.
 
 .. [1]
-   in fact, UNPACK has no effect without
-   -O
-   , for technical reasons (see
-   tick 5252
-   )
+   In fact, ``UNPACK`` has no effect without :ghc-flag:`-O`, for technical
+   reasons (see :ghc-ticket:`5252`).
 
 .. _nounpack-pragma:
 


### PR DESCRIPTION
The ticket 5252 wasn't linked [earlier](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#id84).

I was having a bit of trouble in trying to figure out how to build the documentation, just to double-check that I didn't mess anything up...