### PR TITLE
improve documentation of indexArray#

### DIFF
--- a/compiler/prelude/primops.txt.pp
+++ b/compiler/prelude/primops.txt.pp
@@ -818,7 +818,7 @@ primop  SizeofMutableArrayOp "sizeofMutableArray#" GenPrimOp
 
 primop  IndexArrayOp "indexArray#" GenPrimOp
    Array# a -> Int# -> (# a #)
-   {Read from specified index of immutable array. Result is packaged
+   {Read from the specified index of an immutable array. The result is packaged
     into an unboxed unary tuple; the result itself is not yet
     evaluated. Pattern matching on the tuple forces the indexing of the
     array to happen but does not evaluate the element itself. Evaluating

--- a/compiler/prelude/primops.txt.pp
+++ b/compiler/prelude/primops.txt.pp
@@ -818,14 +818,13 @@ primop  SizeofMutableArrayOp "sizeofMutableArray#" GenPrimOp
 
 primop  IndexArrayOp "indexArray#" GenPrimOp
    Array# a -> Int# -> (# a #)
-   {Read from specified index of immutable array. Result is packaged into
-    an unboxed unary tuple; the result itself is not yet evaluated. Pattern
-    matching on the tuple forces the indexing of the array
-    to happen but does not evaluate the element itself. Doing this
-    pattern match immidiately can be useful for (1) preventing
-    additional thunks from building up on the heap and (2) eliminating
-    references to the argument array, allowing it to be garbage
-    collected more promptly.}
+   {Read from specified index of immutable array. Result is packaged
+    into an unboxed unary tuple; the result itself is not yet
+    evaluated. Pattern matching on the tuple forces the indexing of the
+    array to happen but does not evaluate the element itself. Evaluating
+    the thunk prevents additional thunks from building up on the
+    heap. Avoiding these thunks, in turn, reduces references to the
+    argument array, allowing it to be garbage collected more promptly.}
    with
    can_fail         = True
 

--- a/compiler/prelude/primops.txt.pp
+++ b/compiler/prelude/primops.txt.pp
@@ -819,7 +819,13 @@ primop  SizeofMutableArrayOp "sizeofMutableArray#" GenPrimOp
 primop  IndexArrayOp "indexArray#" GenPrimOp
    Array# a -> Int# -> (# a #)
    {Read from specified index of immutable array. Result is packaged into
-    an unboxed singleton; the result itself is not yet evaluated.}
+    an unboxed unary tuple; the result itself is not yet evaluated. Pattern
+    matching on the tuple forces the indexing of the array
+    to happen but does not evaluate the element itself. Doing this
+    pattern match immidiately can be useful for (1) preventing
+    additional thunks from building up on the heap and (2) eliminating
+    references to the argument array, allowing it to be garbage
+    collected more promptly.}
    with
    can_fail         = True
 


### PR DESCRIPTION
For a long time, I had trouble understanding why the result of this was in an unboxed tuple. The monadic index functions in `primitive` and `vector` obscured its meaning even more for me. This is an attempt at explaining how the promptness of the pattern match on the unboxed tuple can affect people's code.