### PR TITLE
Warn against Data.Semigroup.Option and Data.Monoid.First/Last

### DIFF
--- a/libraries/base/Data/Monoid.hs
+++ b/libraries/base/Data/Monoid.hs
@@ -88,6 +88,16 @@ import Data.Semigroup.Internal
 --
 -- >>> getFirst (First (Just "hello") <> First Nothing <> First (Just "world"))
 -- Just "hello"
+--
+-- Use of this type is discouraged. Note the following equivalence:
+--
+-- > Data.Monoid.First x === Maybe (Data.Semigroup.First x)
+--
+-- In additional to being equivalent in the structural sense, the two
+-- also have 'Monoid' instances that behave the same. This type will
+-- be marked deprecated in GHC 8.8. It will be removed in GHC 8.10.
+-- Users are advised to use the variant from "Data.Semigroup" and wrap
+-- it in 'Maybe'.
 newtype First a = First { getFirst :: Maybe a }
         deriving ( Eq          -- ^ @since 2.01
                  , Ord         -- ^ @since 2.01

--- a/libraries/base/Data/Monoid.hs
+++ b/libraries/base/Data/Monoid.hs
@@ -95,7 +95,7 @@ import Data.Semigroup.Internal
 --
 -- In additional to being equivalent in the structural sense, the two
 -- also have 'Monoid' instances that behave the same. This type will
--- be marked deprecated in GHC 8.8. It will be removed in GHC 8.10.
+-- be marked deprecated in GHC 8.8, and removed in GHC 8.10.
 -- Users are advised to use the variant from "Data.Semigroup" and wrap
 -- it in 'Maybe'.
 newtype First a = First { getFirst :: Maybe a }
@@ -127,6 +127,16 @@ instance Monoid (First a) where
 --
 -- >>> getLast (Last (Just "hello") <> Last Nothing <> Last (Just "world"))
 -- Just "world"
+--
+-- Use of this type is discouraged. Note the following equivalence:
+--
+-- > Data.Monoid.Last x === Maybe (Data.Semigroup.Last x)
+--
+-- In additional to being equivalent in the structural sense, the two
+-- also have 'Monoid' instances that behave the same. This type will
+-- be marked deprecated in GHC 8.8, and removed in GHC 8.10.
+-- Users are advised to use the variant from "Data.Semigroup" and wrap
+-- it in 'Maybe'.
 newtype Last a = Last { getLast :: Maybe a }
         deriving ( Eq          -- ^ @since 2.01
                  , Ord         -- ^ @since 2.01

--- a/libraries/base/Data/Semigroup.hs
+++ b/libraries/base/Data/Semigroup.hs
@@ -455,7 +455,12 @@ mtimesDefault n x
 -- underlying 'Monoid'.
 --
 -- Ideally, this type would not exist at all and we would just fix the
--- 'Monoid' instance of 'Maybe'
+-- 'Monoid' instance of 'Maybe'.
+--
+-- In GHC 8.4 and higher, the 'Monoid' instance for 'Maybe' has been
+-- corrected to lift a 'Semigroup' instance instead of a 'Monoid'
+-- instance. Consequently, this type is no longer useful. It will be
+-- marked deprecated in GHC 8.8 and removed in GHC 8.10.
 newtype Option a = Option { getOption :: Maybe a }
   deriving ( Eq       -- ^ @since 4.9.0.0
            , Ord      -- ^ @since 4.9.0.0


### PR DESCRIPTION
This is phase 1 of https://ghc.haskell.org/trac/ghc/ticket/15028.

cc @ekmett @RyanGlScott 