### PR TITLE
Update docker images to use GHC 8.4.2 and cabal-install-2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ aliases:
     run:
       name: Configure
       command: |
-        setarch i386 ./configure --with-ghc=/opt/ghc-i386/8.2.2/bin/ghc
+        setarch i386 ./configure --with-ghc=/opt/ghc-i386/8.4.2/bin/ghc
   - &configure_bsd
     run:
       name: Configure
@@ -85,7 +85,7 @@ jobs:
   "validate-x86_64-linux":
     resource_class: xlarge
     docker:
-      - image: ghcci/x86_64-linux:0.0.1
+      - image: ghcci/x86_64-linux:0.0.2
     environment:
       <<: *buildenv
       GHC_COLLECTOR_FLAVOR: x86_64-linux
@@ -143,7 +143,7 @@ jobs:
   "validate-hadrian-x86_64-linux":
     resource_class: xlarge
     docker:
-      - image: ghcci/x86_64-linux:0.0.1
+      - image: ghcci/x86_64-linux:0.0.2
     environment:
       <<: *buildenv
     steps:
@@ -157,7 +157,7 @@ jobs:
   "validate-x86_64-linux-unreg":
     resource_class: xlarge
     docker:
-      - image: ghcci/x86_64-linux:0.0.1
+      - image: ghcci/x86_64-linux:0.0.2
     environment:
       <<: *buildenv
     steps:
@@ -172,7 +172,7 @@ jobs:
   "validate-x86_64-linux-llvm":
     resource_class: xlarge
     docker:
-      - image: ghcci/x86_64-linux:0.0.1
+      - image: ghcci/x86_64-linux:0.0.2
     environment:
       <<: *buildenv
       BUILD_FLAVOUR: perf-llvm
@@ -197,7 +197,7 @@ jobs:
   "validate-x86_64-linux-debug":
     resource_class: xlarge
     docker:
-      - image: ghcci/x86_64-linux:0.0.1
+      - image: ghcci/x86_64-linux:0.0.2
     environment:
       BUILD_FLAVOUR: devel2
       <<: *buildenv
@@ -213,7 +213,7 @@ jobs:
   "validate-i386-linux":
     resource_class: xlarge
     docker:
-      - image: ghcci/i386-linux:0.0.1
+      - image: ghcci/i386-linux:0.0.2
     environment:
       <<: *buildenv
       GHC_COLLECTOR_FLAVOR: i386-linux
@@ -231,7 +231,7 @@ jobs:
   "validate-x86_64-fedora":
     resource_class: xlarge
     docker:
-      - image: ghcci/x86_64-linux-fedora:0.0.2
+      - image: ghcci/x86_64-linux-fedora:0.0.3
     environment:
       <<: *buildenv
       GHC_COLLECTOR_FLAVOR: x86_64-fedora

--- a/.circleci/images/i386-linux/Dockerfile
+++ b/.circleci/images/i386-linux/Dockerfile
@@ -1,24 +1,19 @@
-# This Dockerfile tries to replicate haskell:8.2 a bit, but it does so on
-# top of i368/debian:jessie instead of debian:jessie because I had troubles
-# making i386 GHC bindist working there.
-
 FROM i386/debian:jessie
 
 ENV LANG C.UTF-8
 
-# Install the necessary packages, including HVR stuff.
 RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main' > /etc/apt/sources.list.d/ghc.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286
 RUN apt-get update -qq
-RUN apt-get install -qy git make automake autoconf gcc perl python3 texinfo xz-utils lbzip2 bzip2 patch openssh-client sudo curl zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++ cabal-install-2.0 ghc-8.2.2 happy-1.19.5 alex-3.1.7
-ENV PATH /opt/cabal/2.0/bin:/opt/ghc/8.2.2/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.7/bin:$PATH
+RUN apt-get install -qy git make automake autoconf gcc perl python3 texinfo xz-utils lbzip2 bzip2 patch openssh-client sudo curl zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++ cabal-install-2.2 ghc-8.4.2 happy alex
+ENV PATH /home/ghc/.cabal/bin:/home/ghc/.local/bin:/opt/cabal/2.2/bin:/opt/ghc/8.4.2/bin:$PATH
 
 # Get i386 GHC bindist for 32 bit CI builds.
-RUN cd /tmp && curl https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-i386-deb8-linux.tar.xz | tar -Jx
-RUN cd /tmp/ghc-8.2.2 && setarch i386 ./configure --prefix=/opt/ghc-i386/8.2.2 CFLAGS=-m32 --target=i386-unknown-linux --build=i386-unknown-linux --host=i386-unknown-linux
-RUN cd /tmp/ghc-8.2.2 && make install
-RUN rm -rf /tmp/ghc-8.2.2
-ENV PATH /opt/ghc-i386/8.2.2/bin:$PATH
+RUN cd /tmp && curl https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-i386-deb8-linux.tar.xz | tar -Jx
+RUN cd /tmp/ghc-8.4.2 && setarch i386 ./configure --prefix=/opt/ghc-i386/8.4.2 CFLAGS=-m32 --target=i386-unknown-linux --build=i386-unknown-linux --host=i386-unknown-linux
+RUN cd /tmp/ghc-8.4.2 && make install
+RUN rm -rf /tmp/ghc-8.4.2
+ENV PATH /opt/ghc-i386/8.4.2/bin:$PATH
 
 # Create a normal user.
 RUN adduser ghc --gecos "GHC builds" --disabled-password

--- a/.circleci/images/x86_64-linux-fedora/Dockerfile
+++ b/.circleci/images/x86_64-linux-fedora/Dockerfile
@@ -5,12 +5,12 @@ ENV LANG C.UTF-8
 RUN dnf -y install coreutils binutils which git make automake autoconf gcc perl python3 texinfo xz lbzip2 patch openssh-clients sudo curl zlib-devel sqlite ncurses-compat-libs gmp-devel ncurses-devel gcc-c++ findutils
 
 # Install GHC and cabal
-RUN cd /tmp && curl https://downloads.haskell.org/~ghc/8.2.2/ghc-8.2.2-x86_64-deb8-linux.tar.xz | tar -Jx
-RUN cd /tmp/ghc-8.2.2 && ./configure --prefix=/opt/ghc/8.2.2
-RUN cd /tmp/ghc-8.2.2 && make install
+RUN cd /tmp && curl https://downloads.haskell.org/~ghc/8.4.2/ghc-8.4.2-x86_64-deb8-linux.tar.xz | tar -Jx
+RUN cd /tmp/ghc-8.4.2 && ./configure --prefix=/opt/ghc/8.4.2
+RUN cd /tmp/ghc-8.4.2 && make install
 RUN mkdir -p /opt/cabal/bin
-RUN cd /opt/cabal/bin && curl https://www.haskell.org/cabal/release/cabal-install-2.0.0.1/cabal-install-2.0.0.1-x86_64-unknown-linux.tar.gz | tar -zx
-ENV PATH /opt/ghc/8.2.2/bin:/opt/cabal/bin:$PATH
+RUN cd /opt/cabal/bin && curl https://www.haskell.org/cabal/release/cabal-install-2.2.0.0/cabal-install-2.2.0.0-x86_64-unknown-linux.tar.gz | tar -zx
+ENV PATH /opt/ghc/8.4.2/bin:/opt/cabal/bin:$PATH
 
 # Create a normal user.
 RUN adduser ghc --comment "GHC builds"

--- a/.circleci/images/x86_64-linux/Dockerfile
+++ b/.circleci/images/x86_64-linux/Dockerfile
@@ -1,10 +1,23 @@
-FROM haskell:8.2
+FROM debian:jessie
 
-# Make sure we have proper openssh before checkout: CircleCI git
-# does not check the repository out properly without it and also
-# takes 20 times longer than it should be.
+ENV LANG C.UTF-8
+
+RUN echo 'deb http://ppa.launchpad.net/hvr/ghc/ubuntu trusty main' > /etc/apt/sources.list.d/ghc.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6F88286
 RUN apt-get update -qq
-RUN apt-get install -qy git make automake autoconf gcc perl python3 texinfo xz-utils lbzip2 patch openssh-client sudo -qq curl
+RUN apt-get install -qy cabal-install-2.2 ghc-8.4.2 happy alex zlib1g-dev libtinfo-dev libsqlite3-0 libsqlite3-dev ca-certificates g++ git curl git make automake autoconf gcc perl python3 texinfo xz-utils lbzip2 patch openssh-client sudo
+
+# Stack intallation
+RUN curl -fSL https://github.com/commercialhaskell/stack/releases/download/v1.6.5/stack-1.6.5-linux-x86_64-static.tar.gz -o stack.tar.gz
+RUN curl -fSL https://github.com/commercialhaskell/stack/releases/download/v1.6.5/stack-1.6.5-linux-x86_64-static.tar.gz.asc -o stack.tar.gz.asc
+RUN export GNUPGHOME="$(mktemp -d)"
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442
+RUN gpg --batch --verify stack.tar.gz.asc stack.tar.gz
+RUN tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1
+RUN /usr/local/bin/stack config set system-ghc --global true
+RUN rm -rf "$GNUPGHOME" /var/lib/apt/lists/* /stack.tar.gz.asc /stack.tar.gz
+
+ENV PATH /home/ghc/.cabal/bin:/home/ghc/.local/bin:/opt/cabal/2.2/bin:/opt/ghc/8.4.2/bin:$PATH
 
 # Create a normal user.
 RUN adduser ghc --gecos "GHC builds" --disabled-password


### PR DESCRIPTION
The `haskell` images are not being updated and there is no image with GHC 8.4.2, so we probably should not use them anymore. I adapted Dockerfiles used by those images so the end result is almost the same except we get newer GHC and cabal-install.