### PR TITLE
Fix typo in user guide about promoted list

### DIFF
--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -8478,7 +8478,7 @@ Haskell.
 
 .. note::
     The declaration for ``HCons`` also requires :extension:`TypeOperators`
-    because of infix type operator ``(:')``
+    because of infix type operator ``(':)``
 
 
 .. _promotion-existentials:


### PR DESCRIPTION
`:'` in explanation text should be `':` to match code example.