### PR TITLE
Trac #15146 improve the UsersGuide for Lexically scoped type variables

### DIFF
--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -9818,7 +9818,7 @@ Lexically scoped type variables
     To trigger those forms of ``ScopedTypeVariables``, the ``forall`` must appear against the top-level signature (or outer expression)
     but *not* against nested signatures referring to the same type variables.
     
-    Explicit ``forall`` is not always required -- see :ref:`pattern-equiv-form` for the example in this section, or :ref:`pattern-type-sigs`.
+    Explicit ``forall`` is not always required -- see :ref:`pattern-equiv-form` for the example in this section, or :ref:`pattern-type-sigs` .
     
 
 GHC supports *lexically scoped type variables*, without which some type
@@ -9842,9 +9842,9 @@ possible to do so.
 .. _pattern-equiv-form:
 
 Pattern signature equivalent
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
-An equivalent form for that example, avoiding explicit ``forall`` uses :ref:`pattern-type-sigs`::
+An equivalent form for that example, avoiding explicit ``forall`` uses :ref:`pattern-type-sigs`: ::
 
     f :: [a] -> [a]
     f (xs :: [aa]) = xs ++ ys

--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -9809,6 +9809,17 @@ Lexically scoped type variables
     Enable lexical scoping of type variables explicitly introduced with
     ``forall``.
 
+.. tip::
+
+    ``ScopedTypeVariables`` breaks ghc's usual rule that explicit ``forall`` is optional and doesn't affect semantics.
+    For the examples in this section, the explicit ``forall`` is required.
+    (If omitted, usually the program will not compile; in a few cases it will compile but the functions get a different signature.)
+    To trigger ``ScopedTypeVariables``, the ``forall`` must appear against the top-level signature (or outer expression)
+    but *not* against nested signatures referring to the same type variables.
+    
+    Explicit ``forall`` is not always required -- see the equivalent form for the example in this section, or :ref:`Pattern type signatures`.
+    
+
 GHC supports *lexically scoped type variables*, without which some type
 signatures are simply impossible to write. For example: ::
 
@@ -9826,6 +9837,19 @@ scopes over the whole definition of ``f``, including over the type
 signature for ``ys``. In Haskell 98 it is not possible to declare a type
 for ``ys``; a major benefit of scoped type variables is that it becomes
 possible to do so.
+
+An equivalent form for that example, avoiding explicit ``forall`` uses Pattern type signatures::
+
+    f :: [a] -> [a]
+    f (xs :: [aa]) = xs ++ ys
+      where
+        ys :: [aa]
+        ys = reverse xs
+
+Unlike the ``forall`` form, type variable ``a`` from ``f``'s signature is not scoped over ``f``'s equation(s). 
+Type variable ``aa`` bound by the pattern signature is scoped over the right-hand side of ``f``'s equation. 
+(Therefore there is no need to use a distinct type variable; using ``a`` would be equivalent.)
+
 
 Overview
 --------
@@ -9925,10 +9949,12 @@ This only happens if:
          f3 :: forall a. [a] -> [a]
          Just f3 = Just (\(x:xs) -> xs ++ [ x :: a ])   -- Not OK!
 
-   The binding for ``f3`` is a pattern binding, and so its type
-   signature does not bring ``a`` into scope. However ``f1`` is a
-   function binding, and ``f2`` binds a bare variable; in both cases the
-   type signature brings ``a`` into scope.
+   ``f1`` is a function binding, and ``f2`` binds a bare variable; 
+   in both cases the type signature brings ``a`` into scope.
+   However the binding for ``f3`` is a pattern binding, 
+   and so ``f3`` is a fresh variable brought into scope by the pattern,
+   not connected with top level ``f3``. 
+   Then type variable ``a`` is not in scope of the right-hand side of ``Just f3 = ...``.
 
 .. _exp-type-sigs:
 
@@ -9974,7 +10000,7 @@ example: ::
     f xs = (n, zs)
       where
         (ys::[a], n) = (reverse xs, length xs) -- OK
-        zs::[a] = xs ++ ys                     -- OK
+        (zs::[a]) = xs ++ ys                     -- OK
 
         Just (v::b) = ...  -- Not OK; b is not in scope
 
@@ -9983,8 +10009,19 @@ for ``v`` is not because ``b`` is not in scope.
 
 However, in all patterns *other* than pattern bindings, a pattern type
 signature may mention a type variable that is not in scope; in this
-case, *the signature brings that type variable into scope*. This is
-particularly important for existential data constructors. For example: ::
+case, *the signature brings that type variable into scope*. For example: ::
+
+    -- same f and g as above, now assuming that 'a' is not already in scope
+    f = \(x::Int, y::a) -> x           -- 'a' is in scope on RHS
+
+    g (x::a) = x :: a
+
+    hh (Just (v :: b)) = v :: b
+
+The pattern type signature makes the type variable available on the right-hand side of the equation.
+
+Bringing type variables into scope is particularly important 
+for existential data constructors. For example: ::
 
     data T = forall a. MkT [a]
 
@@ -9992,28 +10029,31 @@ particularly important for existential data constructors. For example: ::
     k (MkT [t::a]) =
         MkT t3
       where
-        t3::[a] = [t,t,t]
+        (t3::[a]) = [t,t,t]
 
-Here, the pattern type signature ``(t::a)`` mentions a lexical type
-variable that is not already in scope. Indeed, it *cannot* already be in
-scope, because it is bound by the pattern match. GHC's rule is that in
-this situation (and only then), a pattern type signature can mention a
-type variable that is not already in scope; the effect is to bring it
-into scope, standing for the existentially-bound type variable.
+Here, the pattern type signature ``[t::a]`` mentions a lexical type
+variable that is not already in scope. Indeed, it *must not* already be in
+scope, because it is bound by the pattern match. 
+The effect is to bring it into scope, 
+standing for the existentially-bound type variable.
 
 When a pattern type signature binds a type variable in this way, GHC
 insists that the type variable is bound to a *rigid*, or fully-known,
 type variable. This means that any user-written type signature always
 stands for a completely known type.
 
-If all this seems a little odd, we think so too. But we must have *some*
-way to bring such type variables into scope, else we could not name
-existentially-bound type variables in subsequent type signatures.
+If all this seems a little odd, we think so too. 
+It does seem odd that the existentially-bound type variable *must not* 
+be already in scope. Contrast that usually name-bindings merely shadow 
+(make a 'hole') in a same-named outer variable's scope.
+But we must have *some* way to bring such type variables into scope, 
+else we could not name existentially-bound type variables 
+in subsequent type signatures.
 
-This is (now) the *only* situation in which a pattern type signature is
-allowed to mention a lexical variable that is not already in scope. For
-example, both ``f`` and ``g`` would be illegal if ``a`` was not already
-in scope.
+Compare the two (identical) definitions for examples ``f``, ``g``; 
+they are both legal whether or not ``a`` is already in scope. 
+They differ in that *if* ``a`` is already in scope, the signature constrains 
+the pattern, rather than the pattern binding the variable.
 
 .. _cls-inst-scoped-tyvars:
 

--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -9818,7 +9818,7 @@ Lexically scoped type variables
     To trigger those forms of ``ScopedTypeVariables``, the ``forall`` must appear against the top-level signature (or outer expression)
     but *not* against nested signatures referring to the same type variables.
     
-    Explicit ``forall`` is not always required -- see :ref:`pattern-equiv-form` for the example in this section, or :ref:`pattern-type-sigs` .
+    Explicit ``forall`` is not always required -- see :ref:`pattern signature equivalent pattern-equiv-form` for the example in this section, or :ref:`pattern-type-sigs` .
     
 
 GHC supports *lexically scoped type variables*, without which some type
@@ -9840,9 +9840,6 @@ for ``ys``; a major benefit of scoped type variables is that it becomes
 possible to do so.
 
 .. _pattern-equiv-form:
-
-Pattern signature equivalent
-----------------------------
 
 An equivalent form for that example, avoiding explicit ``forall`` uses :ref:`pattern-type-sigs`: ::
 

--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -10012,7 +10012,7 @@ signature may mention a type variable that is not in scope; in this
 case, *the signature brings that type variable into scope*. For example: ::
 
     -- same f and g as above, now assuming that 'a' is not already in scope
-    f = \(x::Int, y::a) -> x           -- 'a' is in scope on RHS
+    f = \(x::Int, y::a) -> x           -- 'a' is in scope on RHS of ->
 
     g (x::a) = x :: a
 
@@ -10042,7 +10042,6 @@ insists that the type variable is bound to a *rigid*, or fully-known,
 type variable. This means that any user-written type signature always
 stands for a completely known type.
 
-If all this seems a little odd, we think so too. 
 It does seem odd that the existentially-bound type variable *must not* 
 be already in scope. Contrast that usually name-bindings merely shadow 
 (make a 'hole') in a same-named outer variable's scope.

--- a/docs/users_guide/glasgow_exts.rst
+++ b/docs/users_guide/glasgow_exts.rst
@@ -9811,13 +9811,14 @@ Lexically scoped type variables
 
 .. tip::
 
-    ``ScopedTypeVariables`` breaks ghc's usual rule that explicit ``forall`` is optional and doesn't affect semantics.
-    For the examples in this section, the explicit ``forall`` is required.
+    ``ScopedTypeVariables`` breaks GHC's usual rule that explicit ``forall`` is optional and doesn't affect semantics.
+    For the :ref:`decl-type-sigs` (or :ref:`exp-type-sigs`) examples in this section,
+    the explicit ``forall`` is required.
     (If omitted, usually the program will not compile; in a few cases it will compile but the functions get a different signature.)
-    To trigger ``ScopedTypeVariables``, the ``forall`` must appear against the top-level signature (or outer expression)
+    To trigger those forms of ``ScopedTypeVariables``, the ``forall`` must appear against the top-level signature (or outer expression)
     but *not* against nested signatures referring to the same type variables.
     
-    Explicit ``forall`` is not always required -- see the equivalent form for the example in this section, or :ref:`Pattern type signatures`.
+    Explicit ``forall`` is not always required -- see :ref:`pattern-equiv-form` for the example in this section, or :ref:`pattern-type-sigs`.
     
 
 GHC supports *lexically scoped type variables*, without which some type
@@ -9838,7 +9839,12 @@ signature for ``ys``. In Haskell 98 it is not possible to declare a type
 for ``ys``; a major benefit of scoped type variables is that it becomes
 possible to do so.
 
-An equivalent form for that example, avoiding explicit ``forall`` uses Pattern type signatures::
+.. _pattern-equiv-form:
+
+Pattern signature equivalent
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An equivalent form for that example, avoiding explicit ``forall`` uses :ref:`pattern-type-sigs`::
 
     f :: [a] -> [a]
     f (xs :: [aa]) = xs ++ ys
@@ -10000,9 +10006,9 @@ example: ::
     f xs = (n, zs)
       where
         (ys::[a], n) = (reverse xs, length xs) -- OK
-        (zs::[a]) = xs ++ ys                     -- OK
+        (zs::[a])    = xs ++ ys                     -- OK
 
-        Just (v::b) = ...  -- Not OK; b is not in scope
+        Just (v::b)  = ...  -- Not OK; b is not in scope
 
 Here, the pattern signatures for ``ys`` and ``zs`` are fine, but the one
 for ``v`` is not because ``b`` is not in scope.


### PR DESCRIPTION
Changes only to section 10.16.

Also reviewed references/links re ScopedTypeVariables from other sections: no changes needed.