### PR TITLE
make sphinx-build version test work on recent versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -842,7 +842,7 @@ AC_PATH_PROG(SPHINXBUILD,sphinx-build)
 AC_CACHE_CHECK([for version of sphinx-build], fp_cv_sphinx_version,
 changequote(, )dnl
 [if test -n "$SPHINXBUILD"; then
-  fp_cv_sphinx_version=`"$SPHINXBUILD" --version 2>&1 | sed 's/Sphinx\( (sphinx-build)\)\? v\?\([0-9]\.[0-9]\.[0-9]\)/\2/' | head -n1`;
+  fp_cv_sphinx_version=`"$SPHINXBUILD" --version 2>&1 | sed 's/.* v\?\([0-9]\.[0-9]\.[0-9]\)/\1/' | head -n1`;
 fi;
 changequote([, ])dnl
 ])


### PR DESCRIPTION
On Fedora: `/usr/bin/sphinx-build --version` outputs `sphinx-build 1.7.2`.
Dunno what version others are using but at least this change should work for most versions I suppose.