### PR TITLE
Register 'haddockHTMLs' for inplace builds

### DIFF
--- a/utils/ghc-cabal/Main.hs
+++ b/utils/ghc-cabal/Main.hs
@@ -299,7 +299,6 @@ generate directory distdir config_args
                  final_ipi = installedPkgInfo {
                                  Installed.installedUnitId = ipid,
                                  Installed.compatPackageKey = display (packageId pd),
-                                 Installed.haddockHTMLs = [],
                                  Installed.includeDirs = concatMap fixupIncludeDir (Installed.includeDirs installedPkgInfo)
                              }
                  content = Installed.showInstalledPackageInfo final_ipi ++ "\n"


### PR DESCRIPTION
This should help with testing/developing Haddock with inplace GHC's.

Prior to this change, `./inplace/bin/ghc-pkg --global field base haddock-html` would return nothing, even if the HTML directory _was_ present. This is somewhat frustrating because Haddock's test suite relies on `ghc-pkg` to locate Haddock interface files and HTML directories.