### PR TITLE
Attempt to fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,15 @@ addons:
     #- llvm-toolchain-precise-3.7
     - ubuntu-toolchain-r-test
     packages:
-    - cabal-install-2.0
-    - ghc-8.2.1
+    - cabal-install-2.2
+    - ghc-8.4.3
     - alex-3.1.7
     - happy-1.19.5
     - python3
     #- llvm-3.7
 
 before_install:
- - export PATH=/opt/ghc/8.2.1/bin:/opt/cabal/1.24/bin:/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:/usr/lib/llvm-3.7/bin:$PATH
+ - export PATH=/opt/ghc/8.4.3/bin:/opt/cabal/2.2/bin:/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:/usr/lib/llvm-3.7/bin:$PATH
 
 # Be explicit about which protocol to use, such that we don't have to repeat the rewrite command for each.
  - git config remote.origin.url git://github.com/${TRAVIS_REPO_SLUG}.git


### PR DESCRIPTION
[Travis is currently failing](https://travis-ci.org/ghc/ghc/jobs/397651538#L628), with:

> configure: error: GHC 8.2.1 is known to be buggy and cannot bootstrap this GHC release (See Trac 15281); please use GHC 8.2.2 or later.

So this change bumps ghc to 8.4.3 and cabal-install to 2.2

