### PR TITLE
Make boot work if ACLOCAL_PATH is not set

### DIFF
--- a/boot
+++ b/boot
@@ -151,7 +151,7 @@ def autoreconf():
         # Get the normalized ACLOCAL_PATH for Windows
         # This is necessary since on Windows this will be a Windows
         # path, which autoreconf doesn't know doesn't know how to handle.
-        ac_local = os.environ['ACLOCAL_PATH']
+        ac_local = os.getenv('ACLOCAL_PATH', '')
         ac_local_arg = re.sub(r';', r':', ac_local)
         ac_local_arg = re.sub(r'\\', r'/', ac_local_arg)
         ac_local_arg = re.sub(r'(\w):/', r'/\1/', ac_local_arg)


### PR DESCRIPTION
Before, on Windows, through Hadrian:

```
Command: python3 boot --hadrian
Exit code: 1
Stderr:
Traceback (most recent call last):
  File "boot", line 196, in <module>
    autoreconf()
  File "boot", line 154, in autoreconf
    ac_local = os.environ['ACLOCAL_PATH']
  File "C:/Users/ndmit_000/AppData/Local/Programs/stack/x86_64-windows/msys2-20150512/mingw64/lib/python3.6\os.py", line 669, in __getitem__
    raise KeyError(key) from None
KeyError: 'ACLOCAL_PATH'
)
```

After this patch, it works - I just did what [StackOverflow told me](https://stackoverflow.com/questions/4906977/how-do-i-access-environment-variables-from-python). I've now hit this issue twice when trying to build GHC: https://github.com/snowleopard/hadrian/issues/515
