### PR TITLE
#15387 Fix setting testsuite verbose to zero

### DIFF
--- a/testsuite/driver/runtests.py
+++ b/testsuite/driver/runtests.py
@@ -104,7 +104,7 @@ if args.threads:
     config.threads = args.threads
     config.use_threads = True
 
-if args.verbose:
+if args.verbose is not None:
     config.verbose = args.verbose
 config.skip_perf_tests = args.skip_perf_tests
 


### PR DESCRIPTION
Simple fix to faulty handling of 'VERBOSE' command line argument in the testsuite.
Before VERBOSE=0 would get interpreted as VERBOSE not set and defaulting to 3.