### PR TITLE
Unhide GHC.List for haddock

### DIFF
--- a/libraries/base/GHC/List.hs
+++ b/libraries/base/GHC/List.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE CPP, NoImplicitPrelude, ScopedTypeVariables, MagicHash #-}
 {-# LANGUAGE BangPatterns #-}
-{-# OPTIONS_HADDOCK hide #-}
 
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
The unhidden module GHC.OldList recommends using GHC.List instead.
In consequence we should also have haddocks for GHC.List.