### PR TITLE
docs: Fix wrong module name in hsig example

### DIFF
--- a/docs/users_guide/separate_compilation.rst
+++ b/docs/users_guide/separate_compilation.rst
@@ -790,7 +790,7 @@ be able to pick a particular implementation of strings::
         toString s = s
 
     module A where
-        import Text
+        import Str
         z = toString empty
 
 By replacing ``Str.hs`` with a signature ``Str.hsig``, ``A`` (and


### PR DESCRIPTION
In the module signatures section, two modules were defined, `Str` and
`A`, but `A` was importing `Text`, not `Str`.