### PR TITLE
rts: Stop tracing environment variables (fixes #15371)

### DIFF
--- a/rts/Trace.c
+++ b/rts/Trace.c
@@ -478,16 +478,6 @@ void traceOSProcessInfo_(void) {
                                    argc, argv);
             }
         }
-        {
-            int envc = 0; char **envv;
-            getProgEnvv(&envc, &envv);
-            if (envc != 0) {
-                postCapsetVecEvent(EVENT_PROGRAM_ENV,
-                                   CAPSET_OSPROCESS_DEFAULT,
-                                   envc, envv);
-            }
-            freeProgEnvv(envc, envv);
-        }
     }
 }
 


### PR DESCRIPTION
The corresponding ticket is https://ghc.haskell.org/trac/ghc/ticket/15371.

This tracing may cause a security issue as some external tools out there expect user to set credentials in environment variables.

I thought this change was small enough to be accepted on GitHub.

Travis CI failed due to timeout.