### PR TITLE
rts: Flush eventlog in hs_init_ghc (fixes #15440)

### DIFF
--- a/rts/RtsStartup.c
+++ b/rts/RtsStartup.c
@@ -237,6 +237,7 @@ hs_init_ghc(int *argc, char **argv[], RtsConfig rts_config)
     /* Trace some basic information about the process */
     traceWallClockTime();
     traceOSProcessInfo();
+    flushTrace();
 
     /* initialize the storage manager */
     initStorage();

--- a/rts/Trace.c
+++ b/rts/Trace.c
@@ -130,6 +130,13 @@ void resetTracing (void)
     }
 }
 
+void flushTrace (void)
+{
+    if (eventlog_enabled) {
+        flushEventLog();
+    }
+}
+
 void tracingAddCapapilities (uint32_t from, uint32_t to)
 {
     if (eventlog_enabled) {

--- a/rts/Trace.h
+++ b/rts/Trace.h
@@ -295,6 +295,8 @@ void traceHeapProfSampleCostCentre(StgWord8 profile_id,
                                    CostCentreStack *stack, StgWord residency);
 #endif /* PROFILING */
 
+void flushTrace(void);
+
 #else /* !TRACING */
 
 #define traceSchedEvent(cap, tag, tso, other) /* nothing */
@@ -330,6 +332,8 @@ void traceHeapProfSampleCostCentre(StgWord8 profile_id,
 #define traceHeapProfSampleBegin(era) /* nothing */
 #define traceHeapProfSampleCostCentre(profile_id, stack, residency) /* nothing */
 #define traceHeapProfSampleString(profile_id, label, residency) /* nothing */
+
+#define flushTrace() /* nothing */
 
 #endif /* TRACING */
 


### PR DESCRIPTION
The corresponding ticket is https://ghc.haskell.org/trac/ghc/ticket/15440

Without this change RTS often doesn't flush some important events until the process terminates or it doesn't write them at all in case it terminates abnormally.

Here is a list of such events:

* EVENT_WALL_CLOCK_TIME
* EVENT_OS_PROCESS_PID
* EVENT_OS_PROCESS_PPID
* EVENT_RTS_IDENTIFIER
* EVENT_PROGRAM_ARGS
* EVENT_PROGRAM_ENV