### PR TITLE
Fix minor formatting issue in users_guide/bugs.rst

### DIFF
--- a/docs/users_guide/bugs.rst
+++ b/docs/users_guide/bugs.rst
@@ -351,12 +351,14 @@ The Haskell Report demands that, for infix operators ``%``, the following
 identities hold:
 
 ::
+
     (% expr) = \x -> x % expr
     (expr %) = \x -> expr % x
 
 However, the second law is violated in the presence of undefined operators,
 
 ::
+
     (%) = error "urk"
     (() %)         `seq` () -- urk
     (\x -> () % x) `seq` () -- OK, result ()


### PR DESCRIPTION
The original version is rendered [here](https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/bugs.html#operator-sections).