### PR TITLE
doc: Fix command for creating a shared library.

### DIFF
--- a/docs/users_guide/packages.rst
+++ b/docs/users_guide/packages.rst
@@ -1056,7 +1056,7 @@ extra indirection).
 
    .. code-block:: sh
 
-       ghc -shared libHSfoo-1.0-ghcGHCVersion.so A.o B.o C.o
+       ghc -shared -dynamic -o libHSfoo-1.0-ghcGHCVersion.so A.o B.o C.o
 
    Using GHC's version number in the shared object name allows different
    library versions compiled by different GHC versions to be installed


### PR DESCRIPTION
The previous command did not work. The `-o` flag was missing.
Moreover, without `-dynamic`, the `-shared` flag will raise obscure
link errors because GHC will try to use static objects when creating
the shared library.