### PR TITLE
[docs] Add missed specialisations warnings to list of those not enabled by -Wall

### DIFF
--- a/docs/users_guide/using-warnings.rst
+++ b/docs/users_guide/using-warnings.rst
@@ -82,6 +82,8 @@ The following flags are simple ways to select standard "packages" of warnings:
         * :ghc-flag:`-Widentities`
         * :ghc-flag:`-Wredundant-constraints`
         * :ghc-flag:`-Wpartial-fields`
+        * :ghc-flag:`-Wmissed-specialisations`
+        * :ghc-flag:`-Wall-missed-specialisations`
 
 .. ghc-flag:: -Weverything
     :shortdesc: enable all warnings supported by GHC


### PR DESCRIPTION
Enabling `-Weverything` does enable those warnings.