### PR TITLE
FreeBSD amd64 LLVM target

### DIFF
--- a/llvm-targets
+++ b/llvm-targets
@@ -16,6 +16,7 @@
 ,("armv7-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "generic", ""))
 ,("aarch64-unknown-linux-android", ("e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", "generic", "+neon"))
 ,("powerpc64le-unknown-linux", ("e-m:e-i64:64-n32:64", "ppc64le", ""))
+,("amd64-portbld-freebsd", ("e-m:e-i64:64-f80:128-n8:16:32:64-S128", "x86-64", ""))
 ,("arm-unknown-nto-qnx-eabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "arm7tdmi", "+strict-align"))
 ,("i386-apple-darwin", ("e-m:o-p:32:32-f64:32:64-f80:128-n8:16:32-S128", "yonah", ""))
 ,("x86_64-apple-darwin", ("e-m:o-i64:64-f80:128-n8:16:32:64-S128", "core2", ""))

--- a/utils/llvm-targets/gen-data-layout.sh
+++ b/utils/llvm-targets/gen-data-layout.sh
@@ -32,6 +32,9 @@ TARGETS=(
     # Linux ppc64le
     "powerpc64le-unknown-linux"
 
+    # FreeBSD amd64
+    "amd64-portbld-freebsd"
+
     # QNX
     "arm-unknown-nto-qnx-eabi"
 


### PR DESCRIPTION
Needed for `-fllvm` on FreeBSD amd64 systems.