### PR TITLE
No implicit prelude

### DIFF
--- a/compiler/utils/GhcPrelude.hs
+++ b/compiler/utils/GhcPrelude.hs
@@ -18,3 +18,16 @@ import Prelude as X hiding ((<>))
 import Prelude as X
 import Data.Semigroup as X (Semigroup)
 #endif
+
+{-
+Note [Why do we import Prelude here?]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The files ghc-boot-th.cabal, ghc-boot.cabal, ghci.cabal and
+ghc-heap.cabal contain the directive default-extensions:
+NoImplicitPrelude. There are two motivations for this:
+  - Consistency with the compiler directory, which enables
+    NoImplicitPrelude;
+  - Allows loading the above dependent packages with ghc-in-ghci,
+    giving a smoother development experience when adding new
+    extensions.
+-}

--- a/libraries/ghc-boot-th/GHC/ForeignSrcLang/Type.hs
+++ b/libraries/ghc-boot-th/GHC/ForeignSrcLang/Type.hs
@@ -3,6 +3,7 @@ module GHC.ForeignSrcLang.Type
   ( ForeignSrcLang(..)
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Generics (Generic)
 
 data ForeignSrcLang

--- a/libraries/ghc-boot-th/GHC/LanguageExtensions/Type.hs
+++ b/libraries/ghc-boot-th/GHC/LanguageExtensions/Type.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 module GHC.LanguageExtensions.Type ( Extension(..) ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Generics
 
 -- | The language extensions known to GHC.

--- a/libraries/ghc-boot-th/GHC/Lexeme.hs
+++ b/libraries/ghc-boot-th/GHC/Lexeme.hs
@@ -14,6 +14,7 @@ module GHC.Lexeme (
         startsVarSymASCII, isVarSymChar, okSymChar
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Data.Char
 
 -- | Is this character acceptable in a symbol (after the first char)?

--- a/libraries/ghc-boot-th/ghc-boot-th.cabal.in
+++ b/libraries/ghc-boot-th/ghc-boot-th.cabal.in
@@ -29,6 +29,7 @@ source-repository head
 Library
     default-language: Haskell2010
     other-extensions: DeriveGeneric
+    default-extensions: NoImplicitPrelude
 
     exposed-modules:
             GHC.LanguageExtensions.Type

--- a/libraries/ghc-boot/GHC/HandleEncoding.hs
+++ b/libraries/ghc-boot/GHC/HandleEncoding.hs
@@ -1,6 +1,7 @@
 -- | See GHC #10762 and #15021.
 module GHC.HandleEncoding (configureHandleEncoding) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.IO.Encoding (textEncodingName)
 import System.Environment
 import System.IO

--- a/libraries/ghc-boot/GHC/PackageDb.hs
+++ b/libraries/ghc-boot/GHC/PackageDb.hs
@@ -64,6 +64,7 @@ module GHC.PackageDb (
        writePackageDb
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Data.Version (Version(..))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS.Char8

--- a/libraries/ghc-boot/GHC/Serialized.hs
+++ b/libraries/ghc-boot/GHC/Serialized.hs
@@ -18,6 +18,7 @@ module GHC.Serialized (
     serializeWithData, deserializeWithData,
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Data.Bits
 import Data.Word        ( Word8 )
 import Data.Data

--- a/libraries/ghc-boot/ghc-boot.cabal.in
+++ b/libraries/ghc-boot/ghc-boot.cabal.in
@@ -34,6 +34,7 @@ source-repository head
 Library
     default-language: Haskell2010
     other-extensions: DeriveGeneric, RankNTypes, ScopedTypeVariables
+    default-extensions: NoImplicitPrelude
 
     exposed-modules:
             GHC.LanguageExtensions

--- a/libraries/ghc-heap/GHC/Exts/Heap.hs
+++ b/libraries/ghc-heap/GHC/Exts/Heap.hs
@@ -45,6 +45,7 @@ module GHC.Exts.Heap (
     , areBoxesEqual
     ) where
 
+import Prelude
 import GHC.Exts.Heap.Closures
 import GHC.Exts.Heap.ClosureTypes
 import GHC.Exts.Heap.Constants

--- a/libraries/ghc-heap/GHC/Exts/Heap/ClosureTypes.hs
+++ b/libraries/ghc-heap/GHC/Exts/Heap/ClosureTypes.hs
@@ -6,6 +6,7 @@ module GHC.Exts.Heap.ClosureTypes
     , closureTypeHeaderSize
     ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Generics
 
 {- ---------------------------------------------

--- a/libraries/ghc-heap/GHC/Exts/Heap/Closures.hs
+++ b/libraries/ghc-heap/GHC/Exts/Heap/Closures.hs
@@ -20,6 +20,7 @@ module GHC.Exts.Heap.Closures (
     , asBox
     ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Exts.Heap.Constants
 #if defined(PROFILING)
 import GHC.Exts.Heap.InfoTableProf

--- a/libraries/ghc-heap/GHC/Exts/Heap/Constants.hsc
+++ b/libraries/ghc-heap/GHC/Exts/Heap/Constants.hsc
@@ -8,6 +8,7 @@ module GHC.Exts.Heap.Constants
 
 #include "MachDeps.h"
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Data.Bits
 
 wORD_SIZE, tAG_MASK, wORD_SIZE_IN_BITS :: Int

--- a/libraries/ghc-heap/GHC/Exts/Heap/InfoTable.hsc
+++ b/libraries/ghc-heap/GHC/Exts/Heap/InfoTable.hsc
@@ -7,6 +7,7 @@ module GHC.Exts.Heap.InfoTable
 
 #include "Rts.h"
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Exts.Heap.InfoTable.Types
 #if !defined(TABLES_NEXT_TO_CODE)
 import GHC.Exts.Heap.Constants

--- a/libraries/ghc-heap/GHC/Exts/Heap/InfoTable/Types.hsc
+++ b/libraries/ghc-heap/GHC/Exts/Heap/InfoTable/Types.hsc
@@ -8,6 +8,7 @@ module GHC.Exts.Heap.InfoTable.Types
 
 #include "Rts.h"
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Generics
 import GHC.Exts.Heap.ClosureTypes
 import Foreign

--- a/libraries/ghc-heap/GHC/Exts/Heap/InfoTableProf.hsc
+++ b/libraries/ghc-heap/GHC/Exts/Heap/InfoTableProf.hsc
@@ -11,6 +11,7 @@ module GHC.Exts.Heap.InfoTableProf
 #define PROFILING
 #include "Rts.h"
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Exts.Heap.InfoTable.Types
 #if !defined(TABLES_NEXT_TO_CODE)
 import GHC.Exts.Heap.Constants

--- a/libraries/ghc-heap/GHC/Exts/Heap/Utils.hsc
+++ b/libraries/ghc-heap/GHC/Exts/Heap/Utils.hsc
@@ -6,6 +6,7 @@ module GHC.Exts.Heap.Utils (
 
 #include "Rts.h"
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHC.Exts.Heap.Constants
 import GHC.Exts.Heap.InfoTable
 

--- a/libraries/ghc-heap/ghc-heap.cabal.in
+++ b/libraries/ghc-heap/ghc-heap.cabal.in
@@ -28,6 +28,9 @@ library
 
   ghc-options:      -Wall
   cmm-sources:      cbits/HeapPrim.cmm
+
+  default-extensions: NoImplicitPrelude
+
   exposed-modules:  GHC.Exts.Heap
                     GHC.Exts.Heap.Closures
                     GHC.Exts.Heap.ClosureTypes

--- a/libraries/ghci/GHCi/BinaryArray.hs
+++ b/libraries/ghci/GHCi/BinaryArray.hs
@@ -5,6 +5,7 @@
 --
 module GHCi.BinaryArray(putArray, getArray) where
 
+import Prelude
 import Foreign.Ptr
 import Data.Binary
 import Data.Binary.Put (putBuilder)

--- a/libraries/ghci/GHCi/BreakArray.hs
+++ b/libraries/ghci/GHCi/BreakArray.hs
@@ -30,6 +30,7 @@ module GHCi.BreakArray
     ) where
 
 #ifdef GHCI
+import Prelude -- See note [Why do we import Prelude here?]
 import Control.Monad
 import Data.Word
 import GHC.Word

--- a/libraries/ghci/GHCi/CreateBCO.hs
+++ b/libraries/ghci/GHCi/CreateBCO.hs
@@ -13,6 +13,7 @@
 -- | Create real byte-code objects from 'ResolvedBCO's.
 module GHCi.CreateBCO (createBCOs) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHCi.ResolvedBCO
 import GHCi.RemoteTypes
 import GHCi.BreakArray

--- a/libraries/ghci/GHCi/FFI.hsc
+++ b/libraries/ghci/GHCi/FFI.hsc
@@ -17,6 +17,7 @@ module GHCi.FFI
   , freeForeignCallInfo
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Control.Exception
 import Data.Binary
 import GHC.Generics

--- a/libraries/ghci/GHCi/InfoTable.hsc
+++ b/libraries/ghci/GHCi/InfoTable.hsc
@@ -15,6 +15,7 @@ module GHCi.InfoTable
 #endif
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 #ifdef GHCI
 import Foreign
 import Foreign.C

--- a/libraries/ghci/GHCi/Message.hs
+++ b/libraries/ghci/GHCi/Message.hs
@@ -22,6 +22,7 @@ module GHCi.Message
   , Pipe(..), remoteCall, remoteTHCall, readPipe, writePipe
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHCi.RemoteTypes
 import GHCi.FFI
 import GHCi.TH.Binary ()

--- a/libraries/ghci/GHCi/ObjLink.hs
+++ b/libraries/ghci/GHCi/ObjLink.hs
@@ -25,6 +25,7 @@ module GHCi.ObjLink
   , findSystemLibrary
   )  where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHCi.RemoteTypes
 import Control.Exception (throwIO, ErrorCall(..))
 import Control.Monad    ( when )

--- a/libraries/ghci/GHCi/RemoteTypes.hs
+++ b/libraries/ghci/GHCi/RemoteTypes.hs
@@ -17,6 +17,7 @@ module GHCi.RemoteTypes
   , unsafeForeignRefToRemoteRef, finalizeForeignRef
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Control.DeepSeq
 import Data.Word
 import Foreign hiding (newForeignPtr)

--- a/libraries/ghci/GHCi/ResolvedBCO.hs
+++ b/libraries/ghci/GHCi/ResolvedBCO.hs
@@ -6,6 +6,7 @@ module GHCi.ResolvedBCO
   , isLittleEndian
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import SizedSeq
 import GHCi.RemoteTypes
 import GHCi.BreakArray

--- a/libraries/ghci/GHCi/Run.hs
+++ b/libraries/ghci/GHCi/Run.hs
@@ -12,6 +12,7 @@ module GHCi.Run
   ( run, redirectInterrupts
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHCi.CreateBCO
 import GHCi.InfoTable
 import GHCi.FFI

--- a/libraries/ghci/GHCi/Signals.hs
+++ b/libraries/ghci/GHCi/Signals.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 module GHCi.Signals (installSignalHandlers) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Control.Concurrent
 import Control.Exception
 import System.Mem.Weak  ( deRefWeak )

--- a/libraries/ghci/GHCi/StaticPtrTable.hs
+++ b/libraries/ghci/GHCi/StaticPtrTable.hs
@@ -3,6 +3,7 @@
 
 module GHCi.StaticPtrTable ( sptAddEntry ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Data.Word
 import Foreign
 import GHC.Fingerprint

--- a/libraries/ghci/GHCi/TH.hs
+++ b/libraries/ghci/GHCi/TH.hs
@@ -91,6 +91,7 @@ Other Notes on TH / Remote GHCi
     compiler/typecheck/TcSplice.hs
 -}
 
+import Prelude -- See note [Why do we import Prelude here?]
 import GHCi.Message
 import GHCi.RemoteTypes
 import GHC.Serialized

--- a/libraries/ghci/GHCi/TH/Binary.hs
+++ b/libraries/ghci/GHCi/TH/Binary.hs
@@ -7,6 +7,7 @@
 -- This module is full of orphans, unfortunately
 module GHCi.TH.Binary () where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Data.Binary
 import qualified Data.ByteString as B
 import GHC.Serialized

--- a/libraries/ghci/SizedSeq.hs
+++ b/libraries/ghci/SizedSeq.hs
@@ -8,6 +8,7 @@ module SizedSeq
   , sizeSS
   ) where
 
+import Prelude -- See note [Why do we import Prelude here?]
 import Control.DeepSeq
 import Data.Binary
 import Data.List

--- a/libraries/ghci/ghci.cabal.in
+++ b/libraries/ghci/ghci.cabal.in
@@ -29,6 +29,7 @@ source-repository head
 
 library
     default-language: Haskell2010
+    default-extensions: NoImplicitPrelude
     other-extensions:
         BangPatterns
         CPP


### PR DESCRIPTION
Under the mentorship of @ndmitchell, add `import Prelude` where necessary to files in `compiler`, `ghc-boot-th`, `ghc-boot` and `ghci`, update cabal files with `default-extensions: NoImplicitPrelude`.