### PR TITLE
Fix typo in the documentation for Numeric.Natural.

### DIFF
--- a/libraries/base/GHC/Natural.hs
+++ b/libraries/base/GHC/Natural.hs
@@ -124,7 +124,7 @@ divZeroError = raise# divZeroException
 
 -- | Type representing arbitrary-precision non-negative integers.
 --
--- >>> 2^20 :: Natural
+-- >>> 2^100 :: Natural
 -- 1267650600228229401496703205376
 --
 -- Operations whose result would be negative @'Control.Exception.throw'


### PR DESCRIPTION
Hello!

Just a tiny fix mainly for me to familiarize myself with the build process.

This commit makes a fix to the Numeric.Natural documentation, referenced here [#15563](https://ghc.haskell.org/trac/ghc/ticket/15563).