### PR TITLE
Fix test for GCC support for atomics in Autotools

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1303,7 +1303,7 @@ AC_DEFUN([FP_GCC_SUPPORTS__ATOMICS],
 [
    AC_REQUIRE([AC_PROG_CC])
    AC_MSG_CHECKING([whether GCC supports __atomic_ builtins])
-   echo 'int test(int *x) { int y; __atomic_load(&x, &y, __ATOMIC_SEQ_CST); return x; }' > conftest.c
+   echo 'int test(int *x) { int y; __atomic_load(x, &y, __ATOMIC_SEQ_CST); return y; }' > conftest.c
    if $CC -c conftest.c > /dev/null 2>&1; then
        CONF_GCC_SUPPORTS__ATOMICS=YES
        AC_MSG_RESULT([yes])


### PR DESCRIPTION
that check would always fail, even if support for atomic operations was available

```c
conftest.c: In function ‘test’:
conftest.c:1:27: error: size mismatch in argument 2 of ‘__atomic_load’
 int test(int *x) { int y; __atomic_load(&x, &y, __ATOMIC_SEQ_CST); return x; }
                           ^~~~~~~~~~~~~
conftest.c:1:75: warning: returning ‘int *’ from a function with return type ‘int’ makes integer from pointer without a cast [-Wint-conversion]
 int test(int *x) { int y; __atomic_load(&x, &y, __ATOMIC_SEQ_CST); return x; }
```

I noticed that this was fixed in https://github.com/ghc/ghc/commit/ce3897ffd6e7c8b8f36b8e920168bac8c7f836ae but was not preserved by a reverting commit https://github.com/ghc/ghc/commit/d7fa8695324d6e0c3ea77228f9de93d529afc23e

/cc @bgamari @angerman @iliastsi @monoidal
