### PR TITLE
Fix typo in documentation

### DIFF
--- a/compiler/main/HscTypes.hs
+++ b/compiler/main/HscTypes.hs
@@ -1532,7 +1532,7 @@ It's exactly the same for type-family instances.  See Trac #7102
 -}
 
 -- | Interactive context, recording information about the state of the
--- context in which statements are executed in a GHC session.
+-- context in which statements are executed in a GHCi session.
 data InteractiveContext
   = InteractiveContext {
          ic_dflags     :: DynFlags,


### PR DESCRIPTION
Pretty sure this is right, but better take a look when you merge this.