### PR TITLE
Ignore {-# HLINT #-} pragmas, as used by HLint

### DIFF
--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -2937,7 +2937,7 @@ ignoredPrags = Map.fromList (map ignored pragmas)
                      impls = ["hugs", "nhc98", "jhc", "yhc", "catch", "derive"]
                      options_pragmas = map ("options_" ++) impls
                      -- CFILES is a hugs-only thing.
-                     pragmas = options_pragmas ++ ["cfiles", "contract"]
+                     pragmas = options_pragmas ++ ["cfiles", "contract", "hlint"]
 
 oneWordPrags = Map.fromList [
      ("rules", rulePrag),


### PR DESCRIPTION
The newest (as yet unreleased) version of HLint can interpret `{-# HLINT ... #-}` to ignore hints, as per https://github.com/ndmitchell/hlint#ignoring-hints. This change ensures GHC doesn't warn that the pragma is unknown.

As suggested/requested by @simonmar and @angerman