### PR TITLE
Fix sample code of -fprint-explicit-kinds, plus sample when disabling PolyKinds

### DIFF
--- a/docs/users_guide/using.rst
+++ b/docs/users_guide/using.rst
@@ -781,13 +781,16 @@ messages and in GHCi:
 
     .. code-block:: none
 
-        ghci> :set -XPolyKinds
-        ghci> data T a = MkT
-        ghci> :t MkT
-        MkT :: forall (k :: BOX) (a :: k). T a
-        ghci> :set -fprint-explicit-foralls
-        ghci> :t MkT
-        MkT :: forall (k :: BOX) (a :: k). T k a
+           ghci> :set -XPolyKinds
+           ghci> data T a = MkT
+           ghci> :t MkT
+           MkT :: forall k (a :: k). T a
+           ghci> :set -fprint-explicit-kinds
+           ghci> :t MkT
+           MkT :: forall k (a :: k). T k a
+           ghci> :set -XNoPolyKinds
+           ghci> :t MkT
+           MkT :: T * a
 
 .. ghc-flag:: -fprint-explicit-runtime-reps
     :shortdesc: Print ``RuntimeRep`` variables in types which are


### PR DESCRIPTION
- Although the sample is for `-fprint-explicit-kinds`, the sample code uses `-fprint-explicit-foralls` (but perhaps the output used to be correct one of `-fprint-explicit-kinds`).
- Update the output with the recent version of GHC (ver. 8.4.3. I guess it doesn't change in GHC 8.6...)
- Add more samples to clarify the difference of kinds, which tells effect of `-fprint-explicit-kinds` more clearly.