### PR TITLE
Fix docs typo in Bitraversable composition law

### DIFF
--- a/libraries/base/Data/Bitraversable.hs
+++ b/libraries/base/Data/Bitraversable.hs
@@ -55,7 +55,7 @@ import GHC.Generics (K1(..))
 --   @'Data.Functor.Compose.Compose' .
 --    'fmap' ('bitraverse' g1 g2) .
 --    'bitraverse' f1 f2
---     ≡ 'traverse' ('Data.Functor.Compose.Compose' . 'fmap' g1 . f1)
+--     ≡ 'bitraverse' ('Data.Functor.Compose.Compose' . 'fmap' g1 . f1)
 --                  ('Data.Functor.Compose.Compose' . 'fmap' g2 . f2)@
 --
 -- where an /applicative transformation/ is a function


### PR DESCRIPTION
Please accept my apologies for this minuscule pull request, but I feel _fairly_ certain that the documentation contains a bug or typo.

Yesterday, I was writing some Quickcheck properties to check the `Bitraversable` laws for an instance I'd written, and I noticed that, as given in the docs, the _composition_ law didn't compile. Changing `traverse` to `bitraverse` not only made my code compile, it also makes sense when thinking about what the law states.