### PR TITLE
Correct link to GHC API in docs index.

### DIFF
--- a/docs/index.html.in
+++ b/docs/index.html.in
@@ -39,7 +39,7 @@
 
       <LI>
         <P>
-          <B><A HREF="libraries/ghc-@ProjectVersion@/index.html">GHC API</A></B>
+          <B><A HREF="libraries/ghc-@ProjectVersionMunged@/index.html">GHC API</A></B>
         </P>
         <P>
           Documentation for the GHC API.


### PR DESCRIPTION
In the `index.html`, the link to GHC API is broken for GHC HEAD.