### PR TITLE
circleci: install newer version of alex

### DIFF
--- a/.circleci/prepare-system.sh
+++ b/.circleci/prepare-system.sh
@@ -45,7 +45,7 @@ case "$(uname)" in
       fi
     else
       cabal update
-      cabal install --reinstall hscolour
+      cabal install --reinstall hscolour alex
       sudo ln -s /home/ghc/.cabal/bin/HsColour /usr/local/bin/HsColour || true
     fi
     ;;


### PR DESCRIPTION
Currently, CircleCI is broken because of

```configure: error: Alex version 3.1.7 or later is required to compile GHC.```