### PR TITLE
Fix minor correctness issue

### DIFF
--- a/compiler/llvmGen/LlvmCodeGen/Base.hs
+++ b/compiler/llvmGen/LlvmCodeGen/Base.hs
@@ -480,7 +480,7 @@ aliasify (LMGlobal var val) = do
         defVar = LMGlobalVar defLbl ty Internal sect align const
 
         defPtrVar = LMGlobalVar defLbl (LMPointer ty) link Nothing Nothing const
-        aliasVar = LMGlobalVar lbl (LMPointer i8Ptr) link Nothing Nothing Alias
+        aliasVar = LMGlobalVar lbl i8Ptr link Nothing Nothing Alias
         aliasVal = LMBitc (LMStaticPointer defPtrVar) i8Ptr
 
     -- we need to mark the $def symbols as used so LLVM doesn't forget which


### PR DESCRIPTION
The alias is of type i8, so its global variable name
should have type i8*. Anyway we should never deal
with pointers to (i8*)!