### PR TITLE
rebindable-clash-warning-fix : correct warning logic

### DIFF
--- a/compiler/typecheck/TcMatches.hs
+++ b/compiler/typecheck/TcMatches.hs
@@ -944,7 +944,7 @@ tcMonadFailOp orig pat fail_op res_ty
          rebindableSyntax <- xoptM LangExt.RebindableSyntax
        ; desugarFlag      <- xoptM LangExt.MonadFailDesugaring
        ; missingWarning   <- woptM Opt_WarnMissingMonadFailInstances
-       ; if | rebindableSyntax && (desugarFlag || missingWarning)
+       ; if | rebindableSyntax && desugarFlag && missingWarning
               -> warnRebindableClash pat
             | not desugarFlag && missingWarning
               -> emitMonadFailConstraint pat res_ty


### PR DESCRIPTION
A warning of the form "The fallible pattern ... is used together with -XRebindableSyntax. If this is intentional compile with -Wno-missing-monad-fail-instances" is colloquially called a "rebindable clash" warning.

If the rebindable syntax and monad fail desugaring language extensions are enabled, rebindable clash warnings are issued irrespective of the setting of `-Wmissing-monad-fail-instances` flag. This patch fixes that.

We expect:
  - If rebindable syntax is enabled and monad fail desugaring is enabled and the flag `-Wmissing-monadfail-instances` is in effect,  rebindable clash warnings should be displayed;
  - If rebindable syntax is enabled and monad fail desugaring is enabled and the flag `-Wno-missing-monadfail-instances` is in effect, rebindable clash warnings should not be displayed;
  - If rebindable syntax is enabled and monad fail desugaring is not enabled then rebindable clash warnings should not be displayed.
  - If rebindable syntax is not enabled then rebindable clash warnings should not be displayed.

Put another way, we expect rebindable clash warnings iff rebindable syntax is enabled and monad fail desugaring is enabled and the `-Wmissing-monad-fail-instances` flag is set.

Program for testing:
```
{-# LANGUAGE RebindableSyntax, MonadFailDesugaring #-}
{-# OPTIONS_GHC -Wno-missing-monadfail-instances #-}

module Main where

import Prelude

catMaybes xs = do
    Just x <- xs
    return x

main = print 1
```
