### PR TITLE
./boot: silence stdout in "git config" call.

### DIFF
--- a/boot
+++ b/boot
@@ -133,6 +133,7 @@ def boot_pkgs():
                                 dir = dir_)))
 
                 makefile = os.path.join(package, 'GNUmakefile')
+                print('Creating %s' % makefile)
                 with open(makefile, 'w') as f:
                     f.write(dedent(
                         """\

--- a/boot
+++ b/boot
@@ -40,8 +40,9 @@ def check_for_url_rewrites():
               git config --global url."git://github.com/ghc/packages-".insteadOf     git://github.com/ghc/packages/
               git config --global url."http://github.com/ghc/packages-".insteadOf    http://github.com/ghc/packages/
               git config --global url."https://github.com/ghc/packages-".insteadOf   https://github.com/ghc/packages/
-              git config --global url."ssh://git\@github.com/ghc/packages-".insteadOf ssh://git\@github.com/ghc/packages/
-              git config --global url."git\@github.com:/ghc/packages-".insteadOf      git\@github.com:/ghc/packages/
+              git config --global url."ssh://git@github.com/ghc/packages-".insteadOf ssh://git@github.com/ghc/packages/
+              git config --global url."git@github.com:/ghc/packages-".insteadOf      git@github.com:/ghc/packages/
+              git config --global url."git@github.com:ghc/packages-".insteadOf       git@github.com:ghc/packages/
 
             And then:
 

--- a/boot
+++ b/boot
@@ -26,7 +26,7 @@ def die(mesg):
 def check_for_url_rewrites():
     if os.path.isdir('.git') and \
        subprocess.check_output('git config remote.origin.url'.split()).find(b'github.com') != -1 and \
-       subprocess.call(['git', 'config', '--get-regexp', '^url.*github.com/.*/packages-.insteadOf']) != 0:
+       subprocess.call(['git', 'config', '--get-regexp', '^url.*github.com/.*/packages-.insteadOf'], stdout=subprocess.DEVNULL) != 0:
         # If we cloned from github, make sure the url rewrites are set.
         # Otherwise 'git submodule update --init' prints confusing errors.
         die("""\

--- a/boot
+++ b/boot
@@ -28,7 +28,7 @@ def check_for_url_rewrites():
        subprocess.check_output('git config remote.origin.url'.split()).find(b'github.com') != -1 and \
        subprocess.call(['git', 'config', '--get-regexp', '^url.*github.com/.*/packages-.insteadOf'], stdout=subprocess.DEVNULL) != 0:
         # If we cloned from github, make sure the url rewrites are set.
-        # Otherwise 'git submodule update --init' prints confusing errors.
+        # Otherwise 'git submodule update --init --recursive' prints confusing errors.
         die("""\
             It seems you cloned this repository from GitHub. But your git config files
             don't contain the url rewrites that are needed to make this work (GitHub
@@ -46,7 +46,7 @@ def check_for_url_rewrites():
 
             And then:
 
-              git submodule update --init
+              git submodule update --init --recursive
               ./boot
 
             Or start over, and clone the GHC repository from the haskell server:
@@ -83,7 +83,7 @@ def check_boot_packages():
             if not os.path.isfile(license_path):
                 die("""\
                     Error: %s doesn't exist
-                    Maybe you haven't run 'git submodule update --init'?
+                    Maybe you haven't run 'git submodule update --init --recursive'?
                     """ % license_path)
 
 # Create libraries/*/{ghc.mk,GNUmakefile}


### PR DESCRIPTION
This script checks if the git configuration for URL rewriting is present, if
the remote is set to GitHub.  It checks the return code of "git config
--get-regexp '^url.*github.com/.*/packages-.insteadOf'".  But it didn't silence
the output of this command, so it was being sent to standard output, and
probably ultimately to your pager.

Previously, running ./boot on my system without URL rewrite git configuration
started the "less" pager with a buffer containing the output I had to close
with 'q', and it wasn't immediately clear that the buffer wasn't related to my
interaction with the script.

(Unlike applying "git --no-pager config", this commit also silences the output
of "git config --get-regexp '^url.*github.com/.*/packages-.insteadOf'" once the
GitHub URL rewrite configuration is applied.)