### PR TITLE
Write friendlier documentation for Integer

### DIFF
--- a/libraries/integer-gmp/src/GHC/Integer/Type.hs
+++ b/libraries/integer-gmp/src/GHC/Integer/Type.hs
@@ -136,7 +136,11 @@ instance Eq BigNat where
 instance Ord BigNat where
     compare = compareBigNat
 
--- | Invariant: 'Jn#' and 'Jp#' are used iff value doesn't fit in 'S#'
+-- | An unbounded integer type. In contrast with fixed-size integral
+-- types such as 'Int', the 'Integer' type represents the entire
+-- infinite range of integers.
+
+-- Invariant: 'Jn#' and 'Jp#' are used iff value doesn't fit in 'S#'
 --
 -- Useful properties resulting from the invariants:
 --


### PR DESCRIPTION
Since this is one of the first types that we expect users of Haskell to encounter, having reasonable documentation for it is important. This comment ends up in the documentation for `Prelude`, so it ought to explain what an `Integer` is and what it's for, and it should not include references to constructors which are not exported from `Prelude`.

The most interesting thing I could think to point out about `Integer` from a user's perspective is how its infinite nature contrasts with `Int`.