### PR TITLE
Don't lose parantheses in show SomeAsyncException

### DIFF
--- a/libraries/base/GHC/IO/Exception.hs
+++ b/libraries/base/GHC/IO/Exception.hs
@@ -178,7 +178,7 @@ data SomeAsyncException = forall e . Exception e => SomeAsyncException e
 
 -- | @since 4.7.0.0
 instance Show SomeAsyncException where
-    show (SomeAsyncException e) = show e
+    showsPrec p (SomeAsyncException e) = showsPrec p e
 
 -- | @since 4.7.0.0
 instance Exception SomeAsyncException


### PR DESCRIPTION
I'd also like to change the string-based show instances in this file so that they wrap the strings with spaces in parens when precedence is 11 or higher, but I worry that change might be controversial. But hopefully this simpler change is not controversial, since we just preserves any existing parens in the wrapped exception.