### PR TITLE
Fix documentation for -fomit-yields

### DIFF
--- a/docs/users_guide/using-optimisation.rst
+++ b/docs/users_guide/using-optimisation.rst
@@ -707,7 +707,7 @@ by saying ``-fno-wombat``.
     :reverse: -fno-omit-yields
     :category:
 
-    :default: yield points enabled
+    :default: yield points disabled
 
     Tells GHC to omit heap checks when no allocation is
     being performed. While this improves binary sizes by about 5%, it


### PR DESCRIPTION
When `-fomit-yields` is on (default), additional yield points are not added.

The error was introduced in 2c23fff2e03e77187dc4d01f325f5f43a0e7cad2, which was a pure documentation patch and didn't change the default.

/cc @bgamari