### PR TITLE
added Semigroup and Monoid instances for 'Data.Functor.Compose'.

### DIFF
--- a/libraries/base/Data/Semigroup.hs
+++ b/libraries/base/Data/Semigroup.hs
@@ -112,6 +112,7 @@ import           Data.Semigroup.Internal
 import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.Fix
+import           Data.Functor.Compose
 import           Data.Bifoldable
 import           Data.Bifunctor
 import           Data.Bitraversable
@@ -566,3 +567,12 @@ instance Semigroup a => Semigroup (Option a) where
 -- | @since 4.9.0.0
 instance Semigroup a => Monoid (Option a) where
   mempty = Option Nothing
+
+
+-- | Use 'Compose Maybe First' and 'Compose Maybe Last' to get the old First and Last Functor and Applicative instances.
+instance Semigroup m (n a) => Semigroup (Compose m n a) where
+  Compose mnx <> Compose mny = Compose (mnx <> mny)
+
+instance Monoid m (n a) => Monoid (Compose m n a) where
+  mempty = Compose mempty
+

--- a/libraries/base/Data/Semigroup.hs
+++ b/libraries/base/Data/Semigroup.hs
@@ -570,7 +570,7 @@ instance Semigroup a => Monoid (Option a) where
 
 
 -- | Use 'Compose Maybe First' and 'Compose Maybe Last' to get the old First and Last Functor and Applicative instances.
-instance Semigroup m (n a) => Semigroup (Compose m n a) where
+instance Semigroup (m (n a)) => Semigroup (Compose m n a) where
   Compose mnx <> Compose mny = Compose (mnx <> mny)
 
 instance Monoid m (n a) => Monoid (Compose m n a) where


### PR DESCRIPTION
With the 'First' semigroup replacing the wrapped 'Maybe' monoid, it would be nice to have a functor equivalent to the old First monoid. 'Compose Maybe First'.

I'm not sure whether the instance belongs in 'Data.Functor.Compose' or 'Data.Semigroup', but 'Data.Semigroup' seems like more of a grab bag.

This is my first attempt to contribute to GHC. If I'm going about it the wrong way, sorry. Please point me in the right direction.