### PR TITLE
fp_prog_ar.m4: take AR var into consideration

### DIFF
--- a/m4/fp_prog_ar.m4
+++ b/m4/fp_prog_ar.m4
@@ -14,7 +14,8 @@ if test -z "$fp_prog_ar"; then
       fp_prog_ar=$(cygpath -m $fp_prog_ar)
     fi
   else
-    AC_CHECK_TARGET_TOOL([fp_prog_ar], [ar])
+    AC_CHECK_TARGET_TOOL([AR], [ar])
+    fp_prog_ar="$AR"
   fi
 fi
 if test -z "$fp_prog_ar"; then


### PR DESCRIPTION
In ChromeOS and Gentoo we want the ability to use LLVM ar
instead of GNU ar even though both are installed, thus we
pass (for eg) AR=llvm-ar to configure.

Unfortunately GNU ar always gets picked regardless of the
AR setting because the check does not consider the AR var
when setting fp_prog_ar, hence this fix.