### PR TITLE
Fast var set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -116,5 +116,5 @@
 	ignore = untracked
 [submodule "libraries/haskell-transients"]
 	path = libraries/haskell-transients
-	url = https://github.com/PascEll/haskell-transients.git
+	url = git@github.com:PascEll/haskell-transients.git
 	ignore = untracked

--- a/.gitmodules
+++ b/.gitmodules
@@ -110,3 +110,11 @@
 [submodule "libraries/exceptions"]
 	path = libraries/exceptions
 	url = https://gitlab.haskell.org/ghc/packages/exceptions.git
+[submodule "libraries/primitive"]
+	path = libraries/primitive
+	url = https://github.com/haskell/primitive.git
+	ignore = untracked
+[submodule "libraries/haskell-transients"]
+	path = libraries/haskell-transients
+	url = https://github.com/PascEll/haskell-transients.git
+	ignore = untracked

--- a/compiler/GHC/Builtin/Names.hs
+++ b/compiler/GHC/Builtin/Names.hs
@@ -497,6 +497,12 @@ basicKnownKeyNames
         , unsafeEqualityTyConName
         , unsafeReflDataConName
         , unsafeCoercePrimName
+
+        -- unsafePersistNode/shareNode rewrite rule
+        , unsafePersistNodeName
+        , shareNodeName
+        , wordMapTyConName
+        , tWordMapTyConName
     ]
 
 genericTyConNames :: [Name]
@@ -643,6 +649,9 @@ gHC_RECORDS = mkBaseModule (fsLit "GHC.Records")
 
 rOOT_MAIN :: Module
 rOOT_MAIN       = mkMainModule (fsLit ":Main") -- Root module for initialisation
+
+wORD_MAP :: Module
+wORD_MAP = mkModule transientsUnit (mkModuleNameFS (fsLit "WordMap"))
 
 mkInteractiveModule :: Int -> Module
 -- (mkInteractiveMoudule 9) makes module 'interactive:Ghci9'
@@ -1101,16 +1110,6 @@ mconcatName        = varQual gHC_BASE       (fsLit "mconcat")   mconcatClassOpKe
 joinMName, alternativeClassName :: Name
 joinMName            = varQual gHC_BASE (fsLit "join")        joinMIdKey
 alternativeClassName = clsQual mONAD (fsLit "Alternative") alternativeClassKey
-
---
-joinMIdKey, apAClassOpKey, pureAClassOpKey, thenAClassOpKey,
-    alternativeClassKey :: Unique
-joinMIdKey          = mkPreludeMiscIdUnique 750
-apAClassOpKey       = mkPreludeMiscIdUnique 751 -- <*>
-pureAClassOpKey     = mkPreludeMiscIdUnique 752
-thenAClassOpKey     = mkPreludeMiscIdUnique 753
-alternativeClassKey = mkPreludeMiscIdUnique 754
-
 
 -- Functions for GHC extensions
 considerAccessibleName :: Name
@@ -1653,6 +1652,12 @@ fromStaticPtrName =
 fingerprintDataConName :: Name
 fingerprintDataConName =
     dcQual gHC_FINGERPRINT_TYPE (fsLit "Fingerprint") fingerprintDataConKey
+
+shareNodeName, unsafePersistNodeName, wordMapTyConName, tWordMapTyConName :: Name
+shareNodeName = varQual  wORD_MAP (fsLit "shareNode") shareNodeIdKey
+unsafePersistNodeName = varQual  wORD_MAP (fsLit "unsafePersistNode") unsafePersistNodeIdKey
+wordMapTyConName = tcQual  wORD_MAP (fsLit "WordMap") wordMapTyConKey
+tWordMapTyConName = tcQual  wORD_MAP (fsLit "TWordMap") tWordMapTyConKey
 
 {-
 ************************************************************************
@@ -2673,6 +2678,29 @@ bignatCompareWordIdKey     = mkPreludeMiscIdUnique 693
 mkRationalBase2IdKey, mkRationalBase10IdKey :: Unique
 mkRationalBase2IdKey  = mkPreludeMiscIdUnique 700
 mkRationalBase10IdKey = mkPreludeMiscIdUnique 701 :: Unique
+
+------------------------------------------------------
+-- Applicative/Alternative/Monad combinators 750-754 uniques
+------------------------------------------------------
+
+joinMIdKey, apAClassOpKey, pureAClassOpKey, thenAClassOpKey,
+    alternativeClassKey :: Unique
+joinMIdKey          = mkPreludeMiscIdUnique 750
+apAClassOpKey       = mkPreludeMiscIdUnique 751 -- <*>
+pureAClassOpKey     = mkPreludeMiscIdUnique 752
+thenAClassOpKey     = mkPreludeMiscIdUnique 753
+alternativeClassKey = mkPreludeMiscIdUnique 754
+
+
+------------------------------------------------------
+-- haskell-transients 755-759 uniques
+------------------------------------------------------
+
+shareNodeIdKey, unsafePersistNodeIdKey, wordMapTyConKey, tWordMapTyConKey :: Unique
+shareNodeIdKey  = mkPreludeMiscIdUnique 755
+unsafePersistNodeIdKey  = mkPreludeMiscIdUnique 756
+wordMapTyConKey  = mkPreludeMiscIdUnique 757
+tWordMapTyConKey  = mkPreludeMiscIdUnique 758
 
 {-
 ************************************************************************

--- a/compiler/GHC/Core/Coercion.hs
+++ b/compiler/GHC/Core/Coercion.hs
@@ -91,6 +91,8 @@ module GHC.Core.Coercion (
         substCoVarBndr,
         extendTvSubstAndInScope, getCvSubstEnv,
 
+        substCoVarBndrT,
+
         -- ** Lifting
         liftCoSubst, liftCoSubstTyVar, liftCoSubstWith, liftCoSubstWithEx,
         emptyLiftingContext, extendLiftingContext, extendLiftingContextAndInScope,

--- a/compiler/GHC/Core/Opt/Simplify/Env.hs
+++ b/compiler/GHC/Core/Opt/Simplify/Env.hs
@@ -1141,8 +1141,9 @@ substTyVarBndr env tv
 
 substTyVarBndrT :: TSimplEnv s -> TyVar -> ST s (TSimplEnv s, TyVar)
 substTyVarBndrT env tv = do
-  (TTCvSubst in_scope' tv_env' cv_env', tv') <- Type.substTyVarBndrT (getTTCvSubst env) tv
-  return (env { tseInScope = in_scope', tseTvSubst = tv_env', tseCvSubst = cv_env' }, tv')
+  (TTCvSubst in_scope' tv_env' cv_env', !tv') <- Type.substTyVarBndrT (getTTCvSubst env) tv
+  let !env' = env { tseInScope = in_scope', tseTvSubst = tv_env', tseCvSubst = cv_env' }
+  return (env', tv')
 
 substCoVar :: SimplEnv -> CoVar -> Coercion
 substCoVar env tv = Coercion.substCoVar (getTCvSubst env) tv
@@ -1155,8 +1156,9 @@ substCoVarBndr env cv
 
 substCoVarBndrT :: TSimplEnv s -> CoVar -> ST s (TSimplEnv s, CoVar)
 substCoVarBndrT env cv = do
-  (TTCvSubst in_scope' tv_env' cv_env', cv') <- Coercion.substCoVarBndrT (getTTCvSubst env) cv
-  return (env { tseInScope = in_scope', tseTvSubst = tv_env', tseCvSubst = cv_env' }, cv')
+  (TTCvSubst in_scope' tv_env' cv_env', !cv') <- Coercion.substCoVarBndrT (getTTCvSubst env) cv
+  let !env' = env { tseInScope = in_scope', tseTvSubst = tv_env', tseCvSubst = cv_env' }
+  return (env', cv')
 
 substCo :: SimplEnv -> Coercion -> Coercion
 substCo env co = Coercion.substCo (getTCvSubst env) co

--- a/compiler/GHC/Core/Subst.hs
+++ b/compiler/GHC/Core/Subst.hs
@@ -33,7 +33,7 @@ module GHC.Core.Subst (
         cloneBndr, cloneBndrs, cloneIdBndr, cloneIdBndrs, cloneRecIdBndrs,
 
         TSubst(..),
-        transientSubst, persistentSubst, substTyVarBndrT, substCoVarBndrT
+        transientSubst, persistentSubst, substTyT, substTyVarBndrT, substCoVarBndrT
     ) where
 
 import GHC.Prelude
@@ -479,11 +479,7 @@ substBndr subst bndr
 substBndrT :: TSubst s -> Var -> ST s (TSubst s, Var)
 substBndrT subst bndr
   | isTyVar bndr  = substTyVarBndrT subst bndr
-  | isCoVar bndr  = do
-      persistent_subst <- persistentSubst subst
-      -- TODO: Make a substCoVarBndrT version of substCoVarBndr
-      let (subst', bndr') = substCoVarBndr persistent_subst bndr
-      return (transientSubst subst', bndr')
+  | isCoVar bndr  = substCoVarBndrT subst bndr
   | otherwise     = substIdBndrT (text "var-bndr") subst bndr
 
 -- | Applies 'substBndr' to a number of 'Var's, accumulating a new 'Subst' left-to-right

--- a/compiler/GHC/Core/Subst.hs
+++ b/compiler/GHC/Core/Subst.hs
@@ -33,7 +33,7 @@ module GHC.Core.Subst (
         cloneBndr, cloneBndrs, cloneIdBndr, cloneIdBndrs, cloneRecIdBndrs,
 
         TSubst(..),
-        transientSubst, persistentSubst, substTyVarBndrT,
+        transientSubst, persistentSubst, substTyVarBndrT, substCoVarBndrT
     ) where
 
 import GHC.Prelude
@@ -49,7 +49,7 @@ import qualified GHC.Core.Coercion as Coercion
 import GHC.Core.Type hiding
    ( substTy, extendTvSubst, extendCvSubst, extendTvSubstList
    , isInScope, substTyVarBndr, cloneTyVarBndr, substTyVarBndrT )
-import GHC.Core.Coercion hiding ( substCo, substCoVarBndr )
+import GHC.Core.Coercion hiding ( substCo, substCoVarBndr, substCoVarBndrT )
 
 import GHC.Types.Var.Set
 import GHC.Types.Var.Env as InScopeSet
@@ -696,6 +696,12 @@ substCoVarBndr (Subst in_scope id_env tv_env cv_env) cv
   = case Coercion.substCoVarBndr (TCvSubst in_scope tv_env cv_env) cv of
         (TCvSubst in_scope' tv_env' cv_env', cv')
            -> (Subst in_scope' id_env tv_env' cv_env', cv')
+
+substCoVarBndrT :: TSubst s -> CoVar -> ST s (TSubst s, CoVar)
+substCoVarBndrT (TSubst in_scope id_env tv_env cv_env) cv = do
+  (TTCvSubst in_scope' tv_env' cv_env', cv') <-
+    Coercion.substCoVarBndrT (TTCvSubst in_scope tv_env cv_env) cv
+  return (TSubst in_scope' id_env tv_env' cv_env', cv')
 
 -- | See 'GHC.Core.Type.substTy'.
 substTy :: Subst -> Type -> Type

--- a/compiler/GHC/Core/Subst.hs
+++ b/compiler/GHC/Core/Subst.hs
@@ -32,6 +32,8 @@ module GHC.Core.Subst (
         substBndr, substBndrs, substRecBndrs, substTyVarBndr, substCoVarBndr,
         cloneBndr, cloneBndrs, cloneIdBndr, cloneIdBndrs, cloneRecIdBndrs,
 
+        TSubst(..),
+        transientSubst, persistentSubst, substTyVarBndrT,
     ) where
 
 import GHC.Prelude

--- a/compiler/GHC/Core/TyCo/Subst.hs
+++ b/compiler/GHC/Core/TyCo/Subst.hs
@@ -580,9 +580,9 @@ substitution.
 substTyWith :: HasDebugCallStack => [TyVar] -> [Type] -> Type -> Type
 -- Works only if the domain of the substitution is a
 -- superset of the type being substituted into
-substTyWith tvs tys = {-#SCC "substTyWith" #-}
-                      assert (tvs `equalLength` tys )
-                      substTy (zipTvSubst tvs tys)
+substTyWith tvs tys ty = {-#SCC "substTyWith" #-}
+                         assert (tvs `equalLength` tys )
+                         substTy (zipTvSubst tvs tys) ty
 
 -- | Type substitution, see 'zipTvSubst'. Disables sanity checks.
 -- The problems that the sanity checks in substTy catch are described in
@@ -590,9 +590,9 @@ substTyWith tvs tys = {-#SCC "substTyWith" #-}
 -- The goal of #11371 is to migrate all the calls of substTyUnchecked to
 -- substTy and remove this function. Please don't use in new code.
 substTyWithUnchecked :: [TyVar] -> [Type] -> Type -> Type
-substTyWithUnchecked tvs tys
+substTyWithUnchecked tvs tys ty
   = assert (tvs `equalLength` tys )
-    substTyUnchecked (zipTvSubst tvs tys)
+    substTyUnchecked (zipTvSubst tvs tys) ty
 
 -- | Substitute tyvars within a type using a known 'InScopeSet'.
 -- Pre-condition: the 'in_scope' set should satisfy Note [The substitution
@@ -606,8 +606,8 @@ substTyWithInScope in_scope tvs tys ty =
 
 -- | Coercion substitution, see 'zipTvSubst'
 substCoWith :: HasDebugCallStack => [TyVar] -> [Type] -> Coercion -> Coercion
-substCoWith tvs tys = assert (tvs `equalLength` tys )
-                      substCo (zipTvSubst tvs tys)
+substCoWith tvs tys co = assert (tvs `equalLength` tys )
+                         substCo (zipTvSubst tvs tys) co
 
 -- | Coercion substitution, see 'zipTvSubst'. Disables sanity checks.
 -- The problems that the sanity checks in substCo catch are described in
@@ -615,25 +615,25 @@ substCoWith tvs tys = assert (tvs `equalLength` tys )
 -- The goal of #11371 is to migrate all the calls of substCoUnchecked to
 -- substCo and remove this function. Please don't use in new code.
 substCoWithUnchecked :: [TyVar] -> [Type] -> Coercion -> Coercion
-substCoWithUnchecked tvs tys
+substCoWithUnchecked tvs tys co
   = assert (tvs `equalLength` tys )
-    substCoUnchecked (zipTvSubst tvs tys)
+    substCoUnchecked (zipTvSubst tvs tys) co
 
 
 
 -- | Substitute covars within a type
 substTyWithCoVars :: [CoVar] -> [Coercion] -> Type -> Type
-substTyWithCoVars cvs cos = substTy (zipCvSubst cvs cos)
+substTyWithCoVars cvs cos ty = substTy (zipCvSubst cvs cos) ty
 
 -- | Type substitution, see 'zipTvSubst'
 substTysWith :: [TyVar] -> [Type] -> [Type] -> [Type]
-substTysWith tvs tys = assert (tvs `equalLength` tys )
-                       substTys (zipTvSubst tvs tys)
+substTysWith tvs tys ty = assert (tvs `equalLength` tys )
+                          substTys (zipTvSubst tvs tys) ty
 
 -- | Type substitution, see 'zipTvSubst'
 substTysWithCoVars :: [CoVar] -> [Coercion] -> [Type] -> [Type]
-substTysWithCoVars cvs cos = assert (cvs `equalLength` cos )
-                             substTys (zipCvSubst cvs cos)
+substTysWithCoVars cvs cos tys = assert (cvs `equalLength` cos )
+                                 substTys (zipCvSubst cvs cos) tys
 
 -- | Substitute within a 'Type' after adding the free variables of the type
 -- to the in-scope set. This is useful for the case when the free variables
@@ -774,7 +774,7 @@ subst_ty :: TCvSubst -> Type -> Type
 --
 -- Note that the in_scope set is poked only if we hit a forall
 -- so it may often never be fully computed
-subst_ty subst ty
+subst_ty !subst ty
    = go ty
   where
     go (TyVarTy tv)      = substTyVar subst tv
@@ -1306,4 +1306,3 @@ substTyCoBndr subst (Anon af ty)          = (subst, Anon af (substScaledTy subst
 substTyCoBndr subst (Named (Bndr tv vis)) = (subst', Named (Bndr tv' vis))
                                           where
                                             (subst', tv') = substVarBndr subst tv
-

--- a/compiler/GHC/Core/TyCo/Subst.hs
+++ b/compiler/GHC/Core/TyCo/Subst.hs
@@ -52,6 +52,7 @@ module GHC.Core.TyCo.Subst
         checkValidSubst, isValidTCvSubst,
 
         TTCvSubst(..),
+        mkTTCvSubst,
         substTyUncheckedT, substTyVarBndrT,
   ) where
 
@@ -275,6 +276,9 @@ isEmptyTTCvSubst (TTCvSubst _ tenv cenv) = isEmptyVarEnv tenv && isEmptyVarEnv c
 
 mkTCvSubst :: InScopeSet -> (TvSubstEnv, CvSubstEnv) -> TCvSubst
 mkTCvSubst in_scope (tenv, cenv) = TCvSubst in_scope tenv cenv
+
+mkTTCvSubst :: TInScopeSet s -> (TvSubstEnv, CvSubstEnv) -> TTCvSubst s
+mkTTCvSubst in_scope (tenv, cenv) = TTCvSubst in_scope tenv cenv
 
 mkTvSubst :: InScopeSet -> TvSubstEnv -> TCvSubst
 -- ^ Make a TCvSubst with specified tyvar subst and empty covar subst

--- a/compiler/GHC/Core/Type.hs
+++ b/compiler/GHC/Core/Type.hs
@@ -225,7 +225,7 @@ module GHC.Core.Type (
         substTyCoBndr,
         cloneTyVarBndr, cloneTyVarBndrs, lookupTyVar,
 
-        substTyUncheckedT, substTyVarBndrT,
+        mkTTCvSubst, substTyUncheckedT, substTyVarBndrT,
 
         -- * Tidying type related things up for printing
         tidyType,      tidyTypes,

--- a/compiler/GHC/Core/Type.hs
+++ b/compiler/GHC/Core/Type.hs
@@ -194,6 +194,7 @@ module GHC.Core.Type (
         -- * Main type substitution data types
         TvSubstEnv,     -- Representation widely visible
         TCvSubst(..),    -- Representation visible to a few friends
+        TTCvSubst(..),
 
         -- ** Manipulating type substitutions
         emptyTvSubstEnv, emptyTCvSubst, mkEmptyTCvSubst,
@@ -223,6 +224,8 @@ module GHC.Core.Type (
         substVarBndr, substVarBndrs,
         substTyCoBndr,
         cloneTyVarBndr, cloneTyVarBndrs, lookupTyVar,
+
+        substTyUncheckedT, substTyVarBndrT,
 
         -- * Tidying type related things up for printing
         tidyType,      tidyTypes,

--- a/compiler/GHC/Plugins.hs
+++ b/compiler/GHC/Plugins.hs
@@ -89,7 +89,8 @@ import GHC.Core.DataCon
 import GHC.Core.Utils
 import GHC.Core.Make
 import GHC.Core.FVs
-import GHC.Core.Subst hiding( substTyVarBndr, substCoVarBndr, extendCvSubst, extendSubstInScopeSet, substTyVarBndrT )
+import GHC.Core.Subst hiding( substTyVarBndr, substCoVarBndr, extendCvSubst, extendSubstInScopeSet
+                            , substTyVarBndrT, substCoVarBndrT )
        -- These names are also exported by Type
 
 import GHC.Core.Rules

--- a/compiler/GHC/Plugins.hs
+++ b/compiler/GHC/Plugins.hs
@@ -89,7 +89,7 @@ import GHC.Core.DataCon
 import GHC.Core.Utils
 import GHC.Core.Make
 import GHC.Core.FVs
-import GHC.Core.Subst hiding( substTyVarBndr, substCoVarBndr, extendCvSubst, extendSubstInScopeSet )
+import GHC.Core.Subst hiding( substTyVarBndr, substCoVarBndr, extendCvSubst, extendSubstInScopeSet, substTyVarBndrT )
        -- These names are also exported by Type
 
 import GHC.Core.Rules

--- a/compiler/GHC/Types/Unique/FM.hs
+++ b/compiler/GHC/Types/Unique/FM.hs
@@ -40,6 +40,7 @@ module GHC.Types.Unique.FM (
         listToUFM_Directly,
         listToUFM_C,
         listToIdentityUFM,
+        ascListToUFM,
         addToUFM,addToUFM_C,addToUFM_Acc,
         addListToUFM,addListToUFM_C,
         addToUFM_Directly,
@@ -150,6 +151,9 @@ listToUFM_C
   -> [(key, elt)]
   -> UniqFM key elt
 listToUFM_C f = foldl' (\m (k, v) -> addToUFM_C f m k v) emptyUFM
+
+ascListToUFM :: Uniquable key => [(key, elt)] -> UniqFM key elt
+ascListToUFM l = UFM (M.fromAscList (map (\(k, v) -> (getKey $ getUnique k, v)) l))
 
 addToUFM :: Uniquable key => UniqFM key elt -> key -> elt  -> UniqFM key elt
 addToUFM (UFM m) k v = UFM (M.insert (getKey $ getUnique k) v m)

--- a/compiler/GHC/Types/Unique/Set.hs
+++ b/compiler/GHC/Types/Unique/Set.hs
@@ -21,6 +21,7 @@ module GHC.Types.Unique.Set (
         emptyUniqSet,
         unitUniqSet,
         mkUniqSet,
+        mkUniqSetFromAscList,
         addOneToUniqSet, addListToUniqSet,
         delOneFromUniqSet, delOneFromUniqSet_Directly, delListFromUniqSet,
         delListFromUniqSet_Directly,
@@ -74,6 +75,9 @@ unitUniqSet x = UniqSet $ unitUFM x x
 
 mkUniqSet :: Uniquable a => [a]  -> UniqSet a
 mkUniqSet = foldl' addOneToUniqSet emptyUniqSet
+
+mkUniqSetFromAscList :: Uniquable a => [a] -> UniqSet a
+mkUniqSetFromAscList l = UniqSet (ascListToUFM (map (\x -> (x, x)) l))
 
 addOneToUniqSet :: Uniquable a => UniqSet a -> a -> UniqSet a
 addOneToUniqSet (UniqSet set) x = UniqSet (addToUFM set x x)

--- a/compiler/GHC/Types/Var/Env.hs
+++ b/compiler/GHC/Types/Var/Env.hs
@@ -246,7 +246,7 @@ mkInScopeSet :: VarSet -> InScopeSet
 mkInScopeSet in_scope
   = InScope (FastVarSet (WordMap.fromAscList $ map intKeyToWordKey $ varSetToAscList in_scope))
   where
-    intKeyToWordKey (k, v) = (fromIntegral k, v)
+    intKeyToWordKey (k, v) = ((,) $! fromIntegral k) v
 
 extendInScopeSet :: InScopeSet -> Var -> InScopeSet
 extendInScopeSet (InScope in_scope) v
@@ -293,7 +293,7 @@ mkTInScopeSet in_scope = do
   tmap <- WordMap.fromAscListT $ map intKeyToWordKey $ varSetToAscList in_scope
   return $ TInScope (TFastVarSet tmap)
   where
-    intKeyToWordKey (k, v) = (fromIntegral k, v)
+    intKeyToWordKey (k, v) = ((,) $! fromIntegral k) v
 
 extendTInScopeSet :: TInScopeSet s -> Var -> ST s (TInScopeSet s)
 extendTInScopeSet (TInScope in_scope) v
@@ -401,7 +401,7 @@ unsafeGetFreshLocalUniqueT (TInScope (TFastVarSet set)) = do
   case mb_uniq of
     Just (uniq,_)
       | let uniq' = mkLocalUnique (fromIntegral uniq)
-      , not $ uniq' `ltUnique` minLocalUnique 
+      , not $ uniq' `ltUnique` minLocalUnique
       -> return $! incrUnique uniq'
     _ -> return minLocalUnique
 

--- a/compiler/GHC/Unit/Types.hs
+++ b/compiler/GHC/Unit/Types.hs
@@ -67,6 +67,7 @@ module GHC.Unit.Types
    , mainUnitId
    , thisGhcUnitId
    , interactiveUnitId
+   , transientsUnitId
 
    , primUnit
    , bignumUnit
@@ -76,6 +77,7 @@ module GHC.Unit.Types
    , mainUnit
    , thisGhcUnit
    , interactiveUnit
+   , transientsUnit
 
    , isInteractiveModule
    , wiredInUnitIds
@@ -581,10 +583,12 @@ Make sure you change 'GHC.Unit.State.findWiredInUnits' if you add an entry here.
 -}
 
 bignumUnitId, primUnitId, baseUnitId, rtsUnitId,
-  thUnitId, mainUnitId, thisGhcUnitId, interactiveUnitId  :: UnitId
+  thUnitId, mainUnitId, thisGhcUnitId, interactiveUnitId,
+  transientsUnitId  :: UnitId
 
 bignumUnit, primUnit, baseUnit, rtsUnit,
-  thUnit, mainUnit, thisGhcUnit, interactiveUnit  :: Unit
+  thUnit, mainUnit, thisGhcUnit, interactiveUnit,
+  transientsUnit  :: Unit
 
 primUnitId        = UnitId (fsLit "ghc-prim")
 bignumUnitId      = UnitId (fsLit "ghc-bignum")
@@ -593,6 +597,7 @@ rtsUnitId         = UnitId (fsLit "rts")
 thisGhcUnitId     = UnitId (fsLit "ghc")
 interactiveUnitId = UnitId (fsLit "interactive")
 thUnitId          = UnitId (fsLit "template-haskell")
+transientsUnitId  = UnitId (fsLit "haskell-transients")
 
 thUnit            = RealUnit (Definite thUnitId)
 primUnit          = RealUnit (Definite primUnitId)
@@ -601,6 +606,7 @@ baseUnit          = RealUnit (Definite baseUnitId)
 rtsUnit           = RealUnit (Definite rtsUnitId)
 thisGhcUnit       = RealUnit (Definite thisGhcUnitId)
 interactiveUnit   = RealUnit (Definite interactiveUnitId)
+transientsUnit    = RealUnit (Definite transientsUnitId)
 
 -- | This is the package Id for the current program.  It is the default
 -- package Id if you don't specify a package name.  We don't add this prefix
@@ -619,6 +625,7 @@ wiredInUnitIds =
    , rtsUnitId
    , thUnitId
    , thisGhcUnitId
+   , transientsUnitId
    ]
 
 ---------------------------------------------------------------------

--- a/compiler/ghc.cabal.in
+++ b/compiler/ghc.cabal.in
@@ -93,7 +93,8 @@ Library
                    stm,
                    ghc-boot   == @ProjectVersionMunged@,
                    ghc-heap   == @ProjectVersionMunged@,
-                   ghci == @ProjectVersionMunged@
+                   ghci == @ProjectVersionMunged@,
+                   haskell-transients
 
     if os(windows)
         Build-Depends: Win32  >= 2.3 && < 2.13

--- a/hadrian/src/Packages.hs
+++ b/hadrian/src/Packages.hs
@@ -6,7 +6,7 @@ module Packages (
     compareSizes, compiler, containers, deepseq, deriveConstants, directory,
     exceptions, filepath, genapply, genprimopcode, ghc, ghcBignum, ghcBoot, ghcBootTh,
     ghcCompact, ghcConfig, ghcHeap, ghci, ghciWrapper, ghcPkg, ghcPrim, haddock, haskeline,
-    hsc2hs, hp2ps, hpc, hpcBin, integerGmp, integerSimple, iserv, iservProxy,
+    haskellTransients, hsc2hs, hp2ps, hpc, hpcBin, integerGmp, integerSimple, iserv, iservProxy,
     libffi, libiserv, mtl, parsec, pretty, primitive, process, remoteIserv, rts,
     runGhc, stm, templateHaskell, terminfo, text, time, timeout, touchy,
     transformers, unlit, unix, win32, xhtml,
@@ -37,9 +37,10 @@ ghcPackages =
     [ array, base, binary, bytestring, cabalSyntax, cabal, checkPpr, checkExact, countDeps
     , compareSizes, compiler, containers, deepseq, deriveConstants, directory
     , exceptions, filepath, genapply, genprimopcode, ghc, ghcBignum, ghcBoot, ghcBootTh
-    , ghcCompact, ghcConfig, ghcHeap, ghci, ghciWrapper, ghcPkg, ghcPrim, haddock, haskeline, hsc2hs
+    , ghcCompact, ghcConfig, ghcHeap, ghci, ghciWrapper, ghcPkg, ghcPrim, haddock, haskeline
+    , haskellTransients, hsc2hs
     , hp2ps, hpc, hpcBin, integerGmp, integerSimple, iserv, libffi, libiserv, mtl
-    , parsec, pretty, process, rts, runGhc, stm, templateHaskell
+    , parsec, pretty, primitive, process, rts, runGhc, stm, templateHaskell
     , terminfo, text, time, touchy, transformers, unlit, unix, win32, xhtml
     , timeout
     , lintersCommon
@@ -53,7 +54,8 @@ isGhcPackage = (`elem` ghcPackages)
 array, base, binary, bytestring, cabalSyntax, cabal, checkPpr, checkExact, countDeps,
   compareSizes, compiler, containers, deepseq, deriveConstants, directory,
   exceptions, filepath, genapply, genprimopcode, ghc, ghcBignum, ghcBoot, ghcBootTh,
-  ghcCompact, ghcConfig, ghcHeap, ghci, ghciWrapper, ghcPkg, ghcPrim, haddock, haskeline, hsc2hs,
+  ghcCompact, ghcConfig, ghcHeap, ghci, ghciWrapper, ghcPkg, ghcPrim, haddock, haskeline,
+  haskellTransients, hsc2hs,
   hp2ps, hpc, hpcBin, integerGmp, integerSimple, iserv, iservProxy, remoteIserv, libffi, libiserv, mtl,
   parsec, pretty, primitive, process, rts, runGhc, stm, templateHaskell,
   terminfo, text, time, touchy, transformers, unlit, unix, win32, xhtml,
@@ -93,6 +95,7 @@ ghcPkg              = util "ghc-pkg"
 ghcPrim             = lib  "ghc-prim"
 haddock             = util "haddock"
 haskeline           = lib  "haskeline"
+haskellTransients   = lib "haskell-transients"
 hsc2hs              = util "hsc2hs"
 hp2ps               = util "hp2ps"
 hpc                 = lib  "hpc"

--- a/hadrian/src/Settings/Default.hs
+++ b/hadrian/src/Settings/Default.hs
@@ -88,11 +88,13 @@ stage0Packages = do
              , ghci
              , ghcPkg
              , haddock
+             , haskellTransients
              , hsc2hs
              , hpc
              , hpcBin
              , mtl
              , parsec
+             , primitive
              , time
              , templateHaskell
              , text

--- a/hadrian/src/Settings/Packages.hs
+++ b/hadrian/src/Settings/Packages.hs
@@ -159,6 +159,10 @@ packageArgs = do
           ? notM (expr $ anyTargetOs ["freebsd", "solaris2"])? mconcat
           [ builder (Ghc LinkHs) ? arg "-optl-Wl,--export-dynamic" ]
 
+        -------------------------------- haskell-transients -------------------------------
+        , package haskellTransients ?
+          builder (Cabal Flags) ? notStage0 `cabalFlag` "wired-in"
+
         -------------------------------- haddock -------------------------------
         , package haddock ?
           builder (Cabal Flags) ? arg "in-ghc-tree"

--- a/packages
+++ b/packages
@@ -67,4 +67,6 @@ libraries/xhtml              -           -                               https:/
 libraries/exceptions         -           -                               https://github.com/ekmett/exceptions.git
 nofib                        nofib       -                               -
 libraries/stm                -           -                               ssh://git@github.com/haskell/stm.git
+libraries/primitive          -           -                               https://github.com/haskell/primitive.git
+libraries/haskell-transients -           -                               -
 .                            -           ghc.git                         -


### PR DESCRIPTION
Just leaving this here; the effect is mediocre. According to Ticky on the Cabal benchmark, this reduces number of `unsafePersistNode` calls (not sure about the unsafe prefix in hindsight) by 524768 to 524574.

I *think* we could get more leverage by figuring out and focussing on the call sites of `unsafePersistNode` that account for the majority of calls and see whether we can make them amenable to the RULE. But that's a stretch goal; let's focus on your writeup first.