### PR TITLE
[!14776] Testsuite: fix debug_rts detection

### DIFF
--- a/testsuite/mk/test.mk
+++ b/testsuite/mk/test.mk
@@ -124,6 +124,13 @@ else
 RUNTEST_OPTS += -e ghc_with_dynamic_rts=False
 endif
 
+ifeq "$(filter debug, $(GhcRTSWays))" "debug"
+RUNTEST_OPTS += -e config.debug_rts=True
+else
+RUNTEST_OPTS += -e config.debug_rts=False
+endif
+
+
 ifeq "$(GhcWithInterpreter)" "NO"
 RUNTEST_OPTS += -e config.have_interp=False
 else ifeq "$(GhcStage)" "1"


### PR DESCRIPTION
Running the testsuite without Hadrian should set config.debug_rts correctly too.

Upstream MR: [!14776](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14776)